### PR TITLE
Display correct country/institution tab.

### DIFF
--- a/components/EntityDetails.tsx
+++ b/components/EntityDetails.tsx
@@ -101,9 +101,7 @@ const EntityDetails = ({
 
       <Breadcrumbs
         breadcrumbs={[
-          { title: entity.category, 
-            href: `/${entity.category}`
-          },
+          { title: entity.category, href: `/${entity.category}/` },
           {
             title: entity.name,
             href: `/${entity.category}/${entity.id}/`,

--- a/components/EntityDetails.tsx
+++ b/components/EntityDetails.tsx
@@ -101,7 +101,9 @@ const EntityDetails = ({
 
       <Breadcrumbs
         breadcrumbs={[
-          { title: entity.category, href: "/" },
+          { title: entity.category, 
+            href: `/${entity.category}`
+          },
           {
             title: entity.name,
             href: `/${entity.category}/${entity.id}/`,

--- a/components/NavItem.tsx
+++ b/components/NavItem.tsx
@@ -30,6 +30,7 @@ interface NavItemProps extends BoxProps {
 function isActive(path: string, href: string) {
   return (
     path === href ||
+    (path === "//" && href == "/") ||
     (href === "/" &&
       (path.startsWith("/country") || path.startsWith("/institution")))
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -63,10 +63,19 @@ const IndexPage = ({
         "publications or open access levels. You may also search for a specific institution in the search bar at the top right.",
     },
   ];
+  // Set tab index based on pathname
+  const defaultTabIndex = 0;
+  const mapPathTabIndex: { [key: string]: number } = {
+    institution: 1,
+    country: 0,
+  };
+  const [tabIndex, setTabIndex] = React.useState(defaultTabIndex);
+  useEffect(() => {
+    const index = mapPathTabIndex[window.location.pathname.slice(1, -1)];
+    setTabIndex(index);
+  }, []);
 
   // Change text based on tab index
-  const defaultTabIndex = 0;
-  const [tabIndex, setTabIndex] = React.useState(defaultTabIndex);
   const [dashboardText, setDashboardText] = React.useState(
     descriptions[defaultTabIndex]
   );


### PR DESCRIPTION
When clicking on the country or institution breadcrumb from a specific entry it will go back to the index page and show the correct tab.

When using the /country or /institution route it will show the correct tab.