### PR TITLE
Update dashboard text when changing tabs

### DIFF
--- a/components/EntityDetails.tsx
+++ b/components/EntityDetails.tsx
@@ -105,18 +105,14 @@ const EntityDetails = ({ entity, lastUpdated, ...rest }: EntityDetailsProps) => 
           <EntityOATimeseries entity={entity} />
           <EntityOAVolume entity={entity} />
           <EntityPublisherOpen entity={entity} />
-          <EntityFooter lastUpdated={lastUpdated} />
+          <EntityFooter entity={entity} lastUpdated={lastUpdated} />
         </VStack>
       </Card>
     </Box>
   );
 };
 
-interface EntityFooterProps extends BoxProps {
-  lastUpdated: string;
-}
-
-const EntityFooter = ({ lastUpdated }: EntityFooterProps) => {
+const EntityFooter = ({ entity, lastUpdated }: EntityDetailsProps) => {
   return (
     <Flex
       w="full"
@@ -125,7 +121,7 @@ const EntityFooter = ({ lastUpdated }: EntityFooterProps) => {
       justifyContent="space-between"
       py="12px"
     >
-      <Link href="/" textDecorationColor="white !important">
+      <Link href={`/${entity.category}/`} textDecorationColor="white !important">
         <Button variant="dashboard" fontSize="14px" lineHeight="14px">
           <Text>Return to Dashboard</Text>
         </Button>

--- a/e2e/entity.spec.ts
+++ b/e2e/entity.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+
+test("Should navigate to the country tab when clicking on return to dashboard", async ({ page }) => {
+  await page.goto("/country/AUS/");
+  await page.locator("a[href='/country/'] button").click();
+  // Check the url
+  await expect(page).toHaveURL("/country/");
+  // Check the selected tab
+  await expect(page.locator("button[data-test='tab-country']")).toHaveAttribute("aria-selected", "true");
+  // Check the dashboard text
+  await expect(page.locator("h1 + p")).toContainText("Open Access by country");
+});
+
+test("Should navigate to the institution tab when clicking on return to dashboard", async ({ page }) => {
+  await page.goto("/institution/02n415q13/");
+  await page.locator("a[href='/institution/'] button").click();
+  // Check the url
+  await expect(page).toHaveURL("/institution/");
+  // Check the selected tab
+  await expect(page.locator("button[data-test='tab-institution']")).toHaveAttribute("aria-selected", "true");
+  // Check the dashboard text
+  await expect(page.locator("h1 + p")).toContainText("Open Access by institution");
+});

--- a/e2e/entity.spec.ts
+++ b/e2e/entity.spec.ts
@@ -1,5 +1,29 @@
 import { expect, test } from "@playwright/test";
 
+test("Should navigate to the country tab when clicking on country breadcrumb", async ({ page, isMobile }) => {
+  test.skip(isMobile, "This feature is not implemented for Mobile viewports");
+  await page.goto("/country/AUS/");
+  await page.locator("li a[href='/country/']").click();
+  // Check the url
+  await expect(page).toHaveURL("/country/");
+  // Check the selected tab
+  await expect(page.locator("button[data-test='tab-country']")).toHaveAttribute("aria-selected", "true");
+  // Check the dashboard text
+  await expect(page.locator("h1 + p")).toContainText("Open Access by country");
+});
+
+test("Should navigate to the institution tab when clicking on institution breadcrumb", async ({ page, isMobile }) => {
+  test.skip(isMobile, "This feature is not implemented for Mobile viewports");
+  await page.goto("/institution/02n415q13/");
+  await page.locator("li a[href='/institution/']").click();
+  // Check the url
+  await expect(page).toHaveURL("/institution/");
+  // Check the selected tab
+  await expect(page.locator("button[data-test='tab-institution']")).toHaveAttribute("aria-selected", "true");
+  // Check the dashboard text
+  await expect(page.locator("h1 + p")).toContainText("Open Access by institution");
+});
+
 test("Should navigate to the country tab when clicking on return to dashboard", async ({ page }) => {
   await page.goto("/country/AUS/");
   await page.locator("a[href='/country/'] button").click();

--- a/e2e/route.spec.ts
+++ b/e2e/route.spec.ts
@@ -6,33 +6,24 @@ test("Should navigate to the Open Access Dashboard page", async ({ page }) => {
   await page.goto(route);
   await expect(page).toHaveURL(route);
   await expect(page.locator("h1")).toContainText("Open Access Dashboard");
-  await expect(page.locator("button[data-test='tab-country']")).toHaveAttribute(
-    "aria-selected",
-    "true"
-  );
+  await expect(page.locator("button[data-test='tab-country']")).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator("h1 + p")).toContainText("Open Access by country");
 });
 
-test("Should navigate to Open Access Dashboard: Country Tab", async ({
-  page,
-}) => {
+test("Should navigate to Open Access Dashboard: Country Tab", async ({ page }) => {
   const route = "/country/";
   await page.goto(route);
   await expect(page).toHaveURL(route);
-  await expect(page.locator("button[data-test='tab-country']")).toHaveAttribute(
-    "aria-selected",
-    "true"
-  );
+  await expect(page.locator("button[data-test='tab-country']")).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator("h1 + p")).toContainText("Open Access by country");
 });
 
-test("Should navigate to Open Access Dashboard: Institution Tab", async ({
-  page,
-}) => {
+test("Should navigate to Open Access Dashboard: Institution Tab", async ({ page }) => {
   const route = "/institution/";
   await page.goto(route);
   await expect(page).toHaveURL(route);
-  await expect(
-    page.locator("button[data-test='tab-institution']")
-  ).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator("button[data-test='tab-institution']")).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator("h1 + p")).toContainText("Open Access by institution");
 });
 
 // Country

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -51,24 +51,30 @@ const IndexPage = ({ countriesFirstPage, institutionsFirstPage, stats }: Props) 
         "publications or open access levels. You may also search for a specific institution in the search bar at the top right.",
     },
   ];
-  // Set tab index based on pathname
-  const defaultTabIndex = 0;
-  const mapPathTabIndex: { [key: string]: number } = {
-    institution: 1,
-    country: 0,
-  };
-  const [tabIndex, setTabIndex] = React.useState(defaultTabIndex);
-  useEffect(() => {
-    const index = mapPathTabIndex[window.location.pathname.slice(1, -1)];
-    setTabIndex(index);
-  }, []);
 
-  // Change text based on tab index
-  const [dashboardText, setDashboardText] = React.useState(descriptions[defaultTabIndex]);
+  const defaultTabIndex = 0;
+  const [tabIndex, setTabIndex] = React.useState(defaultTabIndex);
+  const [dashboardText, setDashboardText] = React.useState(descriptions[tabIndex]);
+  const mapPathTabIndex: Array<string> = ["country", "institution"];
+
+  // Set tab index and change text based on tab index
   const handleTabsChange = (index: number) => {
     setTabIndex(index);
     setDashboardText(descriptions[index]);
+    const historyState = window.history.state;
+    if (historyState.as === "/country/" || historyState.as === "/institution/") {
+      window.history.replaceState(historyState, "", `/${mapPathTabIndex[index]}/`);
+    }
   };
+
+  // Change tab index and text based on pathname
+  useEffect(() => {
+    let index = mapPathTabIndex.indexOf(window.location.pathname.slice(1, -1));
+    if (index === -1) {
+      index = defaultTabIndex;
+    }
+    handleTabsChange(index);
+  }, []);
 
   // Fetch and update country and institution list on client
   const [countries, setCountries] = React.useState<Array<Entity>>(countriesFirstPage);


### PR DESCRIPTION
- Fix updating dashboard text when going to a specific tab through a breadcrumb.
- Fix going to correct tab when clicking the 'back to dashboard' button from one of the entity pages.
- Update displayed url when switching between tabs, but only after coming from a breadcrumb or the 'back to dashboard' button. This is when the '/country/ ' or '/institution/' path is already in the url. When going directly to the homepage and then switching tabs the path stays '/'.

Replacing #26 