### PR TITLE
Fix/share button

### DIFF
--- a/components/details/SharePopover.tsx
+++ b/components/details/SharePopover.tsx
@@ -30,6 +30,7 @@ import {
   Text,
   useClipboard,
   useDisclosure,
+  useMediaQuery,
   useToast,
   VStack,
 } from "@chakra-ui/react";
@@ -60,14 +61,23 @@ const SharePopover = ({ entity, platform, ...rest }: SharePopoverProps) => {
 
   // Copy link to clipboard and show toast
   const toast = useToast();
+  const [isGreaterThan] = useMediaQuery("(min-width: 400px)");
+
   const openLinkCopyToast = () => {
     // Copy link to clipboard
     onCopy();
 
+    // Set description
+    // Don't show description for very small screens as takes up too much space
+    let description = null;
+    if (isGreaterThan) {
+      description = `${url}`;
+    }
+
     // Show toast
     toast({
       title: "Link copied to clipboard",
-      description: `${url}`,
+      description: description,
       status: "success",
       duration: 2000,
       isClosable: false,

--- a/theme/components/popover.ts
+++ b/theme/components/popover.ts
@@ -17,6 +17,9 @@
 const Popover = {
   variants: {
     sharePopover: {
+      arrow: {
+        ml: { base: "9px", md: 0 }, // Makes sure that the arrow is centred on the button on mobile
+      },
       content: {
         border: "none",
         width: "min-content",


### PR DESCRIPTION
Centre popover arrow and only show URL in copy link toast on larger mobile screens.