### PR TITLE
INF-530: Fix table summary in the Google search results

### DIFF
--- a/components/charts/BreakdownSparkline.tsx
+++ b/components/charts/BreakdownSparkline.tsx
@@ -81,10 +81,9 @@ const BreakdownSparkline = ({ values, colors, width, height, labels, ...rest }: 
     <Box {...rest}>
       <svg width={width} height={height} viewBox={viewBox.join(" ")} preserveAspectRatio="none">
         {rects.map((rect, i) => (
-          <>
-            <Text>{Math.round(rect.width)}%, </Text>
-            <rect key={i} x={rect.x} width={rect.width} height={height} fill={rect.color} />
-          </>
+          <rect key={i} x={rect.x} width={rect.width} height={height} fill={rect.color}>
+            <text>{Math.round(rect.width)}%, </text>
+          </rect>
         ))}
       </svg>
       {element}

--- a/components/charts/BreakdownSparkline.tsx
+++ b/components/charts/BreakdownSparkline.tsx
@@ -73,12 +73,10 @@ const BreakdownSparkline = ({ values, colors, width, height, labels, ...rest }: 
     );
   }
 
-  let valueSummary: string = "";
-  rects.map((rect) => (valueSummary += ` ${Math.round(rect.width)}% `));
-
   // The text included below is for the Google results of the website.
   // The rect is only rendered in the svg, only the text should appear
   // in the Google search results.
+  const valueSummary: string = values.map((value) => `${Math.round(value)}%`).join(" ");
 
   return (
     <Box {...rest}>

--- a/components/charts/BreakdownSparkline.tsx
+++ b/components/charts/BreakdownSparkline.tsx
@@ -73,6 +73,9 @@ const BreakdownSparkline = ({ values, colors, width, height, labels, ...rest }: 
     );
   }
 
+  let valueSummary: string = "";
+  rects.map((rect) => (valueSummary += ` ${Math.round(rect.width)}% `));
+
   // The text included below is for the Google results of the website.
   // The rect is only rendered in the svg, only the text should appear
   // in the Google search results.
@@ -80,10 +83,9 @@ const BreakdownSparkline = ({ values, colors, width, height, labels, ...rest }: 
   return (
     <Box {...rest}>
       <svg width={width} height={height} viewBox={viewBox.join(" ")} preserveAspectRatio="none">
+        {valueSummary}
         {rects.map((rect, i) => (
-          <rect key={i} x={rect.x} width={rect.width} height={height} fill={rect.color}>
-            {` ${Math.round(rect.width)}% `}
-          </rect>
+          <rect key={i} x={rect.x} width={rect.width} height={height} fill={rect.color} />
         ))}
       </svg>
       {element}

--- a/components/charts/BreakdownSparkline.tsx
+++ b/components/charts/BreakdownSparkline.tsx
@@ -73,14 +73,19 @@ const BreakdownSparkline = ({ values, colors, width, height, labels, ...rest }: 
     );
   }
 
+  // The text included below is for the Google results of the website.
+  // The rect is only rendered in the svg, only the text should appear
+  // in the Google search results.
+
   return (
     <Box {...rest}>
       <svg width={width} height={height} viewBox={viewBox.join(" ")} preserveAspectRatio="none">
-        return (
         {rects.map((rect, i) => (
-          <rect key={i} x={rect.x} width={rect.width} height={height} fill={rect.color} />
+          <>
+            <Text>{Math.round(rect.width)}%, </Text>
+            <rect key={i} x={rect.x} width={rect.width} height={height} fill={rect.color} />
+          </>
         ))}
-        )
       </svg>
       {element}
     </Box>

--- a/components/charts/BreakdownSparkline.tsx
+++ b/components/charts/BreakdownSparkline.tsx
@@ -82,7 +82,7 @@ const BreakdownSparkline = ({ values, colors, width, height, labels, ...rest }: 
       <svg width={width} height={height} viewBox={viewBox.join(" ")} preserveAspectRatio="none">
         {rects.map((rect, i) => (
           <rect key={i} x={rect.x} width={rect.width} height={height} fill={rect.color}>
-            <text>{Math.round(rect.width)}%, </text>
+            {` ${Math.round(rect.width)}% `}
           </rect>
         ))}
       </svg>

--- a/components/table/Header.tsx
+++ b/components/table/Header.tsx
@@ -33,6 +33,7 @@ const ColumnHeaders: { [id: string]: string } = {
 };
 
 function Header({ column }: ColumnProps) {
+  const subHeadings = ["Publisher open", "both", "other platform open", "closed"];
   return (
     <span>
       <HStack align="start" spacing="0">
@@ -49,8 +50,11 @@ function Header({ column }: ColumnProps) {
       </HStack>
       {column.id === "breakdown" ? (
         <Text textStyle="tableSubHeader">
-          Publisher open <br />
-          both <br /> other platform open <br /> closed <br />
+          <table>
+            {subHeadings.map((subHead: string) => {
+              return <tr>{subHead}</tr>;
+            })}
+          </table>
         </Text>
       ) : (
         ""

--- a/components/table/Header.tsx
+++ b/components/table/Header.tsx
@@ -15,7 +15,7 @@
 // Author: James Diprose
 
 import { ColumnInstance } from "react-table";
-import { HStack, Text } from "@chakra-ui/react";
+import { Grid, GridItem, HStack, Text } from "@chakra-ui/react";
 import { ArrowDownIcon, ArrowUpIcon } from "@chakra-ui/icons";
 import React, { memo } from "react";
 
@@ -49,13 +49,15 @@ function Header({ column }: ColumnProps) {
         )}
       </HStack>
       {column.id === "breakdown" ? (
-        <Text textStyle="tableSubHeader">
-          <table>
-            {subHeadings.map((subHead: string) => {
-              return <tr>{subHead}</tr>;
-            })}
-          </table>
-        </Text>
+        <Grid key="subHeadingTable">
+          {subHeadings.map((subHead: string) => {
+            return (
+              <GridItem key={subHead}>
+                <Text textStyle="tableSubHeader">{subHead}</Text>
+              </GridItem>
+            );
+          })}
+        </Grid>
       ) : (
         ""
       )}


### PR DESCRIPTION
I believe I have found why there was a "return ()" in the Google search results. There was an extra return in the SVG for the breakdown sparkline. I have changed it to a text component with the relative percentages of the open/closed statistics. The Text is hidden in the SVG and does not show on the page. 
These changes don't change the look of the site at all. 

We will need to test it on an open domain without and authentication wall so Google's API can scrape the webpage for the summary statistics. 