### PR TITLE
INF-542: Display countries/institutions as cards for mobile. 

### DIFF
--- a/components/charts/BreakdownSparkline.tsx
+++ b/components/charts/BreakdownSparkline.tsx
@@ -79,7 +79,7 @@ const BreakdownSparkline = ({ values, colors, width, height, labels, ...rest }: 
   const valueSummary: string = values.map((value) => `${Math.round(value)}%`).join(" ");
 
   return (
-    <Box {...rest}>
+    <Box {...rest} pt={{ base: "3px", smm: "none" }} width={{ base: "110%", smm: "100%" }}>
       <svg width={width} height={height} viewBox={viewBox.join(" ")} preserveAspectRatio="none">
         {valueSummary}
         {rects.map((rect, i) => (

--- a/components/table/BreakdownCell.tsx
+++ b/components/table/BreakdownCell.tsx
@@ -31,7 +31,8 @@ function BreakdownCell({ entity }: EntityProps) {
   const colors = ["#ffd700", "#4fa9dc", "#9FD27E", "#EBEBEB"];
   return (
     <Link href={href}>
-      <BreakdownSparkline values={values} colors={colors} width={110} height={17} />
+      {/* <BreakdownSparkline values={values} colors={colors} width={110} height={17} /> */}
+      <BreakdownSparkline values={values} colors={colors} width={{ base: 100, smm: 50 }} height={17} />
     </Link>
   );
 }

--- a/components/table/EntityCell.tsx
+++ b/components/table/EntityCell.tsx
@@ -27,7 +27,7 @@ function EntityCell({ entity }: EntityProps) {
         <Box width="16px" height="16px" minWidth="16px">
           <Image rounded="full" objectFit="cover" boxSize="16px" src={entity.logo_s} />
         </Box>
-        <Text>{entity.name}</Text>
+        <Text size={{ base: "m", smm: "s" }}>{entity.name}</Text>
       </HStack>
     </Link>
   );

--- a/components/table/Header.tsx
+++ b/components/table/Header.tsx
@@ -15,7 +15,7 @@
 // Author: James Diprose
 
 import { ColumnInstance } from "react-table";
-import { Grid, GridItem, HStack, Text } from "@chakra-ui/react";
+import { Flex, Grid, GridItem, HStack, Text } from "@chakra-ui/react";
 import { ArrowDownIcon, ArrowUpIcon } from "@chakra-ui/icons";
 import React, { memo } from "react";
 
@@ -32,36 +32,63 @@ const ColumnHeaders: { [id: string]: string } = {
   openPublications: "Open Publications",
 };
 
+const ColumnHeadersMobile: { [id: string]: string } = {
+  Institution: "AZ",
+  Country: "AZ",
+  openPublications: "Open",
+  totalPublications: "Total",
+  open: "Open%",
+};
+
 function Header({ column }: ColumnProps) {
   const subHeadings = ["Publisher open", "both", "other platform open", "closed"];
   return (
-    <span>
-      <HStack align="start" spacing="0">
-        <Text>{ColumnHeaders[column.id]}</Text>
-        {column.isSorted ? (
-          column.isSortedDesc ? (
-            <ArrowDownIcon viewBox=" 0 -2 24 24" />
+    <>
+      {/* Desktop */}
+      <Flex display={{ base: "none", smm: "block" }}>
+        <HStack align="start" spacing="0">
+          <Text>{ColumnHeaders[column.id]}</Text>
+          {column.isSorted ? (
+            column.isSortedDesc ? (
+              <ArrowDownIcon viewBox=" 0 -2 24 24" />
+            ) : (
+              <ArrowUpIcon viewBox=" 0 -2 24 24" />
+            )
           ) : (
-            <ArrowUpIcon viewBox=" 0 -2 24 24" />
-          )
+            <ArrowDownIcon viewBox="0 0 0 0" />
+          )}
+        </HStack>
+        {column.id === "breakdown" ? (
+          <Grid key="subHeadingTable">
+            {subHeadings.map((subHead: string) => {
+              return (
+                <GridItem key={subHead}>
+                  <Text textStyle="tableSubHeader">{subHead}</Text>
+                </GridItem>
+              );
+            })}
+          </Grid>
         ) : (
-          <ArrowDownIcon viewBox="0 0 0 0" />
+          ""
         )}
-      </HStack>
-      {column.id === "breakdown" ? (
-        <Grid key="subHeadingTable">
-          {subHeadings.map((subHead: string) => {
-            return (
-              <GridItem key={subHead}>
-                <Text textStyle="tableSubHeader">{subHead}</Text>
-              </GridItem>
-            );
-          })}
-        </Grid>
-      ) : (
-        ""
-      )}
-    </span>
+      </Flex>
+
+      {/* Mobile */}
+      <Flex pl="20px" display={{ base: "block", smm: "none" }}>
+        <HStack align="start" spacing="0">
+          <Text>{ColumnHeadersMobile[column.id]}</Text>
+          {column.isSorted ? (
+            column.isSortedDesc ? (
+              <ArrowDownIcon viewBox=" 0 -2 24 24" />
+            ) : (
+              <ArrowUpIcon viewBox=" 0 -2 24 24" />
+            )
+          ) : (
+            <ArrowDownIcon viewBox="0 0 0 0" />
+          )}
+        </HStack>
+      </Flex>
+    </>
   );
 }
 

--- a/components/table/IndexTable.tsx
+++ b/components/table/IndexTable.tsx
@@ -14,7 +14,23 @@
 //
 // Author: James Diprose, Aniek Roelofs
 
-import { Box, BoxProps, Flex, Table, Tbody, Td, Text, Th, Thead, Tr } from "@chakra-ui/react";
+import {
+  Box,
+  BoxProps,
+  Flex,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+  Grid,
+  GridItem,
+  VStack,
+  Spacer,
+} from "@chakra-ui/react";
+import { Card, CardHeader, CardBody, CardFooter } from "@chakra-ui/react";
 import React, { memo } from "react";
 import { Cell, Row, usePagination, useSortBy, useTable } from "react-table";
 import { Entity, QueryResult } from "../../lib/model";
@@ -69,8 +85,8 @@ const IndexTable = ({
         accessor: "name",
         Cell: EntityCell,
         minWidth: 100,
-        maxWidth: 220,
         width: "45%",
+        display: { base: "block", smm: "none" },
       },
       {
         Header: Header,
@@ -91,6 +107,7 @@ const IndexTable = ({
         maxWidth: 200,
         width: "12.5%",
         disableSortBy: true,
+        display: { base: "none", smm: "block" },
       },
       {
         Header: Header,
@@ -121,6 +138,7 @@ const IndexTable = ({
         accessor: (e: any) => e,
         width: "5%",
         disableSortBy: true,
+        display: { base: "none", smm: "block" },
       },
     ],
     [categoryName],
@@ -201,8 +219,10 @@ const IndexTable = ({
         {isLoading && (
           <Box position="absolute" zIndex={1} backgroundColor="rgba(0,0,0,0.05)" width="100%" height="100%"></Box>
         )}
+
+        {/* Desktop */}
         {/*The table*/}
-        <Table {...getTableProps()} size="sm" variant="dashboard">
+        <Table {...getTableProps()} size="sm" variant="dashboard" display={{ base: "none", smm: "table" }}>
           <Thead>
             {headerGroups.map((headerGroup) => {
               let props = headerGroup.getHeaderGroupProps();
@@ -253,7 +273,72 @@ const IndexTable = ({
             {data.length == 0 && <SkeletonResults nRows={8} />}
           </Tbody>
         </Table>
+
+        {/* Mobile. Countries and institutions render as cards */}
+        <Box display={{ base: "block", smm: "none" }}>
+          {/* TODO: Change header table to a one row grid using chakra ui*/}
+
+          <Table {...getTableProps()} size="sm" variant="dashboard" display={{ base: "table", smm: "none" }}>
+            <Thead>
+              {headerGroups.map((headerGroup) => {
+                let props = headerGroup.getHeaderGroupProps();
+                return (
+                  <Tr key={props.key}>
+                    {headerGroup.headers.map((column: any) => {
+                      const props = column.getHeaderProps(column.getSortByToggleProps());
+                      return (
+                        <Th
+                          key={props.key}
+                          {...props}
+                          minWidth={column.minWidth}
+                          maxWidth={column.maxWidth}
+                          width={column.width}
+                          display={column.display}
+                        >
+                          {column.render("Header")}
+                        </Th>
+                      );
+                    })}
+                  </Tr>
+                );
+              })}
+            </Thead>
+          </Table>
+
+          <VStack align="center" p="20px">
+            {page.map((row: Row<any>) => {
+              prepareRow(row);
+              return (
+                <Card variant="dashboard" key={row.id}>
+                  <CardHeader display="flex">
+                    {row.cells[0].render("Cell", { entity: row.original })}
+                    <Spacer />
+                    {row.cells[1].render("Cell", { entity: row.original })}
+                  </CardHeader>
+
+                  <CardBody>
+                    <Grid templateColumns="repeat(8, 1fr)" templateRows="repeat(2, 1fr)">
+                      <GridItem colSpan={3}>
+                        <Text>Open: {row.cells[4].render("Cell", { entity: row.original })}</Text>
+                      </GridItem>
+                      <GridItem colSpan={3}>
+                        <Text>Total: {row.cells[3].render("Cell", { entity: row.original })}</Text>
+                      </GridItem>
+                      <GridItem colSpan={4}>{row.cells[2].render("Cell", { entity: row.original })}</GridItem>
+                      <GridItem colSpan={4}>
+                        <Flex justifyContent="right">{row.cells[5].render("Cell", { entity: row.original })}</Flex>
+                      </GridItem>
+                    </Grid>
+                  </CardBody>
+
+                  <CardFooter display="none"></CardFooter>
+                </Card>
+              );
+            })}
+          </VStack>
+        </Box>
       </Box>
+
       <Flex
         w="full"
         alignItems="center"

--- a/theme/components/card.ts
+++ b/theme/components/card.ts
@@ -1,0 +1,68 @@
+// Copyright 2022 Curtin University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Alex Massen-Hane
+
+const Card = {
+    variants: {
+			dashboard: {
+        
+				container: {
+					size: "s",
+					direction: "column",
+					width: "95%",
+					height: "100%",
+					p: "5px", 
+					
+					borderColor: "gray.100",
+      		        borderWidth: "1px",
+					borderRadius: "0",
+    			    // borderStyle: "solid",
+    			    // boxSizing: "border-box",
+
+					// _even: {
+					// 	background: "#F9FAFA"
+					// 	},
+					// _odd: {
+					// 	background: "white",
+					// },
+				},
+
+				header: {
+					p: "5px",
+					pt: "20px",
+					pl: "22px",
+					pr: "20px",
+					height: "5%",
+					fontWeight: 500,
+        	fontSize: "15px",
+					textStyle: "tableCell",
+					textTransform: "uppercase",
+					fontVariantNumeric: "tabular-nums",
+					
+
+				},
+				body: {
+					textStyle: "tableCell",
+					textTransform: "uppercase",
+					fontWeight: 500,
+        	fontSize: "13px",
+
+				}
+			},
+	  },
+  };
+  
+  
+export default Card;

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -18,6 +18,7 @@ import { extendTheme } from "@chakra-ui/react";
 import Accordion from "./components/accordion";
 import Button from "./components/button";
 import Checkbox from "./components/checkbox";
+import Card from "./components/card";
 import Popover from "./components/popover";
 import Slider from "./components/slider";
 import Table from "./components/table";
@@ -29,12 +30,13 @@ import Tooltip from "./components/tooltip";
 import Alert from "./components/alert";
 
 const breakpoints = {
-  sm: "600px",
-  md: "1000px",
-  std: "1310px",
-  lg: "1600px",
-  xl: "1920px",
-  "2xl": "3840px",
+  sm: "600px",   // small mobile
+  smm: "700px",  // small medium mobile
+  md: "1000px",  // mobile device
+  std: "1310px", // standard
+  lg: "1600px",  // large
+  xl: "1920px",  // extra large
+  "2xl": "3840px", 
 };
 
 const theme = extendTheme({
@@ -362,6 +364,7 @@ const theme = extendTheme({
     Accordion,
     Button,
     Checkbox,
+    Card,
     Slider,
     Table,
     Tabs,


### PR DESCRIPTION
Countries and institutions now display as cards under a page width of 700px instead of a scrollable left/right table. 
To do:
 - Fix title/header spacing for columns that were removed from the old table. 
 - Add a legend for the breakdown sparkline in the header/top of the page.
 - Make styling adjustments for iPhone and fringe cases.
 - Adjust unit tests to suit.

![image](https://user-images.githubusercontent.com/104514872/211245155-a3f3fe89-7744-4a4b-a648-3833c1785ee5.png)


