### PR TITLE
Add yarn cache files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 # Yarn 3 files
 .pnp.*
 .yarn
+.yarnrc.yml
 
 # production
 /build

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@
 
 # Yarn 3 files
 .pnp.*
-.yarn/*
 .yarn
 
 # production

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@
 /.next/
 /out/
 
+# Yarn 3 files
+.pnp.*
+.yarn/*
+.yarn
+
 # production
 /build
 

--- a/package.json
+++ b/package.json
@@ -69,5 +69,6 @@
   },
   "workspaces": [
     "workers-api"
-  ]
+  ],
+  "packageManager": "yarn@3.3.1"
 }


### PR DESCRIPTION
Add .yarn cache to .gitignore so VS Code doesn't get confused with cached packages.