### PR TITLE
Fix 500 errors

### DIFF
--- a/components/details/SharePopover.tsx
+++ b/components/details/SharePopover.tsx
@@ -34,10 +34,10 @@ import {
   useToast,
   VStack,
 } from "@chakra-ui/react";
-import React, { memo } from "react";
+import React, { memo, ReactElement } from "react";
 import { FiLink2, FiShare2 } from "react-icons/fi";
 import { FaFacebook, FaLinkedin, FaTwitter } from "react-icons/fa";
-
+import Link from "../common/Link";
 import { useRouter } from "next/router";
 import { Entity } from "../../lib/model";
 
@@ -90,13 +90,6 @@ const SharePopover = ({ entity, platform, ...rest }: SharePopoverProps) => {
   const encodedUrl = encodeURIComponent(url);
   const shareLinks = [
     {
-      text: "Link",
-      href: url,
-      icon: <FiLink2 size={size} />,
-      action: openLinkCopyToast,
-      description: "Copy link to clipboard.",
-    },
-    {
       text: "Twitter",
       href: `https://twitter.com/intent/tweet?text=${text}&url=${encodedUrl}&hashtags=OpenAccess,COKI&via=COKIproject`,
       icon: <FaTwitter size={size} />,
@@ -132,29 +125,35 @@ const SharePopover = ({ entity, platform, ...rest }: SharePopoverProps) => {
             <PopoverArrow />
             <PopoverBody>
               <Grid templateRows="repeat(3)" templateColumns="repeat(2, 1fr)" justifyItems="center" gap="12px">
-                {shareLinks.map((item) => {
+                <GridItem key="share-link">
+                  <ShareIconButton
+                    dataTest="share-link"
+                    icon={<FiLink2 size={size} />}
+                    text="Link"
+                    description="Copy link to clipboard."
+                    onClick={() => {
+                      openLinkCopyToast();
+                      // Close popover
+                      onClose();
+                    }}
+                  />
+                </GridItem>
+
+                {shareLinks.map(item => {
                   const id = `share-${item.text.toLowerCase()}`;
                   return (
                     <GridItem key={id}>
-                      <IconButton
-                        data-test={id}
-                        variant="iconText"
-                        aria-label={item.description}
-                        onClick={() => {
-                          // Run action
-                          item.action(item.href);
-
-                          // Close popover
-                          onClose();
-                        }}
-                      >
-                        <VStack>
-                          {item.icon}
-                          <Text marginTop="3px !important" fontSize="14px">
-                            {item.text}
-                          </Text>
-                        </VStack>
-                      </IconButton>
+                      <Link data-test={id} href={item.href} isExternal>
+                        <ShareIconButton
+                          icon={item.icon}
+                          text={item.text}
+                          description={item.description}
+                          onClick={() => {
+                            // Close popover
+                            onClose();
+                          }}
+                        />
+                      </Link>
                     </GridItem>
                   );
                 })}
@@ -164,6 +163,27 @@ const SharePopover = ({ entity, platform, ...rest }: SharePopoverProps) => {
         </Portal>
       </Popover>
     </Box>
+  );
+};
+
+interface ShareIconButtonProps {
+  icon: ReactElement;
+  text: string;
+  description: string;
+  onClick: () => void;
+  dataTest?: string;
+}
+
+const ShareIconButton = ({ icon, text, description, onClick, dataTest }: ShareIconButtonProps) => {
+  return (
+    <IconButton data-test={dataTest} variant="iconText" aria-label={description} onClick={onClick}>
+      <VStack>
+        {icon}
+        <Text marginTop="3px !important" fontSize="14px">
+          {text}
+        </Text>
+      </VStack>
+    </IconButton>
   );
 };
 

--- a/e2e/share-popover.spec.ts
+++ b/e2e/share-popover.spec.ts
@@ -19,7 +19,7 @@ test("Should check that the share popover window opens", async ({ page, isMobile
   await expect(page.locator(`section[data-test="${platform}-share-popover-content"]`)).toBeVisible();
 });
 
-test("Should check that social share links open new tabs with correct URLs", async ({ page, isMobile, context }) => {
+test("Should check that social share links have the correct URLs", async ({ page, isMobile }) => {
   // Get platform
   let platform = "desktop";
   if (isMobile) {
@@ -31,48 +31,27 @@ test("Should check that social share links open new tabs with correct URLs", asy
   // Nagivate to a page with the share button
   await page.locator("tr[data-test='IDN'] > td:first-of-type > a").click();
 
-  const openShareLink = async (dataTest: string) => {
-    await page.bringToFront();
+  // Click the share button to open the popup
+  await page.locator(`button[data-test="${platform}-share-button"]`).click();
 
-    const newTabPromise = new Promise((resolve) => context.once("page", resolve));
+  // Find share popover
+  const sharePopoverContent = page.locator(`section[data-test='${platform}-share-popover-content']`);
 
-    // Click the share button to open the popup
-    await page.locator(`button[data-test="${platform}-share-button"]`).click();
-
-    // Click link button
-    const sharePopoverContent = page.locator(`section[data-test='${platform}-share-popover-content']`);
-    await sharePopoverContent.locator(`button[data-test='${dataTest}']`).click();
-
-    // Return new tab
-    const newTab = await newTabPromise;
-    await newTab.waitForTimeout(1000);
-    await newTab.bringToFront();
-
-    return newTab;
-  };
-
-  // Check that correct tabs are opened
-  let newTab = await openShareLink("share-twitter");
-  expect(newTab.url()).toEqual(
+  // Check that hrefs are set to correct values for each sharing link
+  const twitter = await sharePopoverContent.locator(`a[data-test='share-twitter']`);
+  expect(await twitter.getAttribute("href")).toEqual(
     "https://twitter.com/intent/tweet?text=Check%20out%20the%20Open%20Access%20statistics%20for%20Indonesia%20on%20the%20COKI%20Open%20Access%20Dashboard%3A&url=http%3A%2F%2Flocalhost%3A3000%2Fcountry%2FIDN%2F&hashtags=OpenAccess,COKI&via=COKIproject",
   );
-  await newTab.close();
 
-  newTab = await openShareLink("share-linkedin");
-  let params = new URLSearchParams(new URL(newTab.url()).search);
-  expect(params.get("session_redirect")).toEqual(
+  const facebook = await sharePopoverContent.locator(`a[data-test='share-facebook']`);
+  expect(await facebook.getAttribute("href")).toEqual(
+    "https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Flocalhost%3A3000%2Fcountry%2FIDN%2F",
+  );
+
+  const linkedin = await sharePopoverContent.locator(`a[data-test='share-linkedin']`);
+  expect(await linkedin.getAttribute("href")).toEqual(
     "https://www.linkedin.com/shareArticle?mini=true&url=http%3A%2F%2Flocalhost%3A3000%2Fcountry%2FIDN%2F",
   );
-  await newTab.close();
-
-  newTab = await openShareLink("share-facebook");
-  params = new URLSearchParams(new URL(newTab.url()).search);
-  let expected = "https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Flocalhost%3A3000%2Fcountry%2FIDN%2F";
-  if (isMobile) {
-    expected = "https://m.facebook.com/sharer/sharer.php?u=http%3A%2F%2Flocalhost%3A3000%2Fcountry%2FIDN%2F";
-  }
-  expect(params.get("next")).toEqual(expected);
-  await newTab.close();
 });
 
 test("Should check that copy link button actually copies link to clipboard", async ({

--- a/next.config.js
+++ b/next.config.js
@@ -26,6 +26,17 @@ module.exports = {
     );
     return config;
   },
+  async redirects() {
+    return [
+      // At one point in time the social cards were hosted on the https://open.coki.ac/social-cards path
+      // Hence we need to redirect them to their new location
+      {
+        source: "/social-cards/:slug",
+        destination: "https://images.open.coki.ac/social-cards/:slug",
+        permanent: true,
+      },
+    ];
+  },
   async rewrites() {
     return [
       {

--- a/pages/[entityType]/[id].tsx
+++ b/pages/[entityType]/[id].tsx
@@ -38,6 +38,23 @@ type Params = {
 };
 
 export async function getStaticProps({ params }: Params) {
+  // Validate the entityType parameter
+  if (!["country", "institution"].includes(params.entityType)) {
+    return { notFound: true };
+  }
+
+  // Validate country ID
+  // Three letter ISO code
+  if (params.entityType === "country" && !/^[A-Z]{3}$/.test(params.id)) {
+    return { notFound: true };
+  }
+
+  // Validate institution ID
+  // ROR ID pattern: https://ror.readme.io/docs/ror-identifier-pattern
+  if (params.entityType === "institution" && !/^0[a-hj-km-np-tv-z|0-9]{6}[0-9]{2}$/.test(params.id)) {
+    return { notFound: true };
+  }
+
   // Use REST API to fetch data for entities as this function can be called
   // at build time or run time for ISR (for blocking fallback pages).
   const client = new OADataAPI();

--- a/pages/licenses.tsx
+++ b/pages/licenses.tsx
@@ -148,7 +148,7 @@ const getLicenseInfo = (licensesData: LicensesData) => {
   return licenses;
 };
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   const webAppLicensesData = webAppLicensesJson as LicensesData;
   const apiLicensesData = apiLicensesJson as LicensesData;
   const webAppLicenses = getLicenseInfo(webAppLicensesData);


### PR DESCRIPTION
On the country and institution pages, validate the entityType and id.
Change licenses page to a static page.
Redirect old social card URLs.
Update sharing to use real links rather than JavaScript so that users can see what they are clicking on and fix tests.