### PR TITLE
Make sure that node_modules is kept within dashboard workspace

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -73,6 +73,9 @@
     "uuid": "^9.0.0",
     "vercel": "^28.8.0"
   },
+  "installConfig": {
+    "hoistingLimits": "workspaces"
+  },
   "browser": {
     "fs": false
   }


### PR DESCRIPTION
After moving the Next.js front end code into it's own yarn 3 workspace the following errors occured when navigating to server rendered routes:
```bash
2023-09-12T00:29:59.594Z	undefined	ERROR	Cannot find module 'next/dist/server/next-server.js'
Require stack:
- /var/task/___next_launcher.cjs
2023-09-12T00:29:59.594Z	undefined	ERROR	Did you forget to add it to "dependencies" in `package.json`?
RequestId: XXXXXXX Error: Runtime exited with error: exit status 1
Runtime.ExitError
```

It turns out the Vercel requires the node_modules folder to be in the same directory as the `dashboard` workspace (yarn 3 puts them in the root by default).