### PR TITLE
Fix Curtin link in footer and rename Curtin Institute for Computation…

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -4,7 +4,7 @@
   "license": {
     "id": "Apache-2.0"
   },
-  "notes": "The Curtin Open Knowledge Initiative (COKI) is a strategic initiative of the Research Office at Curtin, the Faculty of Humanities, School of Media, Creative Arts and Social Inquiry and the Curtin Institute for Computation, with additional support from the Mellon Foundation and the Arcadia Fund, a charitable fund of Lisbet Rausing and Peter Baldwin.",
+  "notes": "The Curtin Open Knowledge Initiative (COKI) is a strategic initiative of the Research Office at Curtin, the Faculty of Humanities, School of Media, Creative Arts and Social Inquiry and the Curtin Institute for Data Science, with additional support from the Mellon Foundation and the Arcadia Fund, a charitable fund of Lisbet Rausing and Peter Baldwin.",
   "communities": [
     {
       "identifier": "coki"
@@ -32,16 +32,16 @@
     },
     {
       "orcid": "0000-0003-0485-3388",
-      "affiliation": "Curtin Institute for Computation, Curtin University",
+      "affiliation": "Curtin Institute for Data Science, Curtin University",
       "name": "Aniek Roelofs"
     },
     {
-      "affiliation": "Curtin Institute for Computation, Curtin University",
+      "affiliation": "Curtin Institute for Data Science, Curtin University",
       "name": "Alex Massen-Hane"
     },
     {
       "orcid": "0000-0003-1202-7238",
-      "affiliation": "Curtin Institute for Computation, Curtin University",
+      "affiliation": "Curtin Institute for Data Science, Curtin University",
       "name": "Kathryn R. Napier"
     },
     {

--- a/dashboard/src/layouts/Footer.tsx
+++ b/dashboard/src/layouts/Footer.tsx
@@ -35,7 +35,7 @@ const Footer = ({ links, sidebarWidth, ...rest }: FooterProps) => {
       {/*Left side of the footer that makes the sidebar look like part of the footer*/}
       <Box w={sidebarWidth} minWidth={sidebarWidth} bg="grey.400" display={{ base: "none", std: "block" }}>
         <Flex alignItems="center" justifyContent="center" h="full">
-          <a href="components/layout/Footer" target="_blank" rel="noreferrer">
+          <a href="https://www.curtin.edu.au/" target="_blank" rel="noreferrer">
             <Box minWidth={curtinLogoWidthDesktop} width={curtinLogoWidthDesktop}>
               <CurtinLogo />
             </Box>
@@ -69,7 +69,7 @@ const Footer = ({ links, sidebarWidth, ...rest }: FooterProps) => {
         >
           <FooterCredits />
           <Box mb={{ base: "24px", sm: 0 }}>
-            <a href="components/layout/Footer" target="_blank" rel="noreferrer">
+            <a href="https://www.curtin.edu.au/" target="_blank" rel="noreferrer">
               <Box minWidth={curtinLogoWidthMobile} width={curtinLogoWidthMobile}>
                 <CurtinLogo />
               </Box>

--- a/dashboard/src/pages/about.tsx
+++ b/dashboard/src/pages/about.tsx
@@ -62,9 +62,9 @@ export default function About() {
         </Text>
         <Text textStyle="p" layerStyle="pGap">
           The Curtin Open Knowledge Initiative (COKI) is a strategic initiative of the Research Office at Curtin, the
-          Faculty of Humanities, School of Media, Creative Arts and Social Inquiry and the Curtin Institute for
-          Computation, with additional support from the Mellon Foundation and Arcadia, a charitable fund of Lisbet
-          Rausing and Peter Baldwin.
+          Faculty of Humanities, School of Media, Creative Arts and Social Inquiry and the Curtin Institute for Data
+          Science, with additional support from the Mellon Foundation and Arcadia, a charitable fund of Lisbet Rausing
+          and Peter Baldwin.
         </Text>
 
         <Text as="h2" textStyle="h2">


### PR DESCRIPTION
Fix Curtin link in footer and rename Curtin Institute for Computation to Curtin Institute for Data Science.