### PR TITLE
Make sure that Tab buttons are styled with SSR

### DIFF
--- a/dashboard/src/components/dashboard/Dashboard.tsx
+++ b/dashboard/src/components/dashboard/Dashboard.tsx
@@ -326,6 +326,7 @@ const Dashboard = ({ defaultEntityType, defaultCountries, defaultInstitutions, s
             {/*We use Button rather than Tab, because Tab cannot be selected by default and it's styling wil flash */}
             <Button
               variant={tabIndexToEntity(tabIndex) === "country" ? "tabActive" : "tabInactive"}
+              aria-selected={tabIndexToEntity(tabIndex) === "country"}
               data-test="tab-country"
               onClick={() => {
                 setTabIndex(entityToTabIndex("country"));
@@ -337,6 +338,7 @@ const Dashboard = ({ defaultEntityType, defaultCountries, defaultInstitutions, s
 
             <Button
               variant={tabIndexToEntity(tabIndex) === "institution" ? "tabActive" : "tabInactive"}
+              aria-selected={tabIndexToEntity(tabIndex) === "institution"}
               data-test="tab-institution"
               onClick={() => {
                 setTabIndex(entityToTabIndex("institution"));

--- a/dashboard/src/theme/components/button.ts
+++ b/dashboard/src/theme/components/button.ts
@@ -165,6 +165,39 @@ const Button = {
       p: { base: "12px 12px", sm: "8px 32px" },
     },
 
+    // Active tab style
+    tabActive: {
+      height: "60px",
+      flex: 1,
+      borderRadius: 0,
+      color: "brand.500",
+      fontWeight: 900,
+      textTransform: "uppercase",
+      fontSize: "16px",
+      bgColor: "white",
+      _focus: {
+        boxShadow: "none",
+      },
+    },
+
+    // Inactive tab style
+    tabInactive: {
+      height: "60px",
+      flex: 1,
+      borderRadius: 0,
+      color: "#b7b7b7",
+      fontWeight: 900,
+      textTransform: "uppercase",
+      fontSize: "16px",
+      bgColor: "#f0f0f0",
+      _focus: {
+        boxShadow: "none",
+      },
+      _hover: {
+        textDecoration: "none",
+      },
+    },
+
     // Share button
     share: {
       ...solidStyle,


### PR DESCRIPTION
The ChakraUI `Tab` component does not render properly with SSR, resulting in all `Tab` components starting off as being unselected when the page loads, when one of them should be selected (causing a jarring flash from unselected to selected when JavaScript loads). This PR uses custom styled buttons instead of the `Tab` components to workaround this.

Related issues:
* https://github.com/chakra-ui/chakra-ui/issues/4506
* https://github.com/chakra-ui/chakra-ui/issues/5146