### PR TITLE
Clearbit migration

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -26,7 +26,7 @@ jobs:
           yarn run build # Creates ../data/data/db.sql
           # NOTE: revert this line if wrangler ever gets fixed.
           # yarn run wrangler d1 execute DB --file ../data/data/db.sql --local --config wrangler.local.toml
-          ./bin/load_entities.sh ..
+          ../bin/load_entities.sh ..
 
       - name: Run e2e Tests
         working-directory: ./dashboard

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,12 +19,14 @@ jobs:
           playwright: true
 
       - name: Load Local D1 Database
-        working-directory: ./workers-api
+        # working-directory: ./workers-api
         env:
           WRANGLER_LOG: error # yarn run wrangler d1 prints out too much information so only log errors
         run: |
           yarn run build # Creates ../data/data/db.sql
-          yarn run wrangler d1 execute DB --file ../data/data/db.sql --local --config wrangler.local.toml
+          # NOTE: revert this line if wrangler ever gets fixed. Also change back the working directory above
+          # yarn run wrangler d1 execute DB --file ../data/data/db.sql --local --config wrangler.local.toml
+          ./bin/load_entities.sh .
 
       - name: Run e2e Tests
         working-directory: ./dashboard
@@ -39,3 +41,4 @@ jobs:
           mv test-results ${FOLDER}
           gsutil -m cp -R ${FOLDER} gs://${{ secrets.TEST_ARTIFACT_BUCKET_NAME }}/e2e-tests/${FOLDER}
         shell: bash
+

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,14 +19,14 @@ jobs:
           playwright: true
 
       - name: Load Local D1 Database
-        # working-directory: ./workers-api
+        working-directory: ./workers-api
         env:
           WRANGLER_LOG: error # yarn run wrangler d1 prints out too much information so only log errors
         run: |
           yarn run build # Creates ../data/data/db.sql
-          # NOTE: revert this line if wrangler ever gets fixed. Also change back the working directory above
+          # NOTE: revert this line if wrangler ever gets fixed.
           # yarn run wrangler d1 execute DB --file ../data/data/db.sql --local --config wrangler.local.toml
-          ./bin/load_entities.sh .
+          ./bin/load_entities.sh ..
 
       - name: Run e2e Tests
         working-directory: ./dashboard
@@ -41,4 +41,3 @@ jobs:
           mv test-results ${FOLDER}
           gsutil -m cp -R ${FOLDER} gs://${{ secrets.TEST_ARTIFACT_BUCKET_NAME }}/e2e-tests/${FOLDER}
         shell: bash
-

--- a/bin/load_entities.sh
+++ b/bin/load_entities.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# This loads all of the entities into the D1 database.
+# This script shouldn't be necessary, but wrangler is extremely unstable and complains when processing
+# too much data at once.
+# So instead, we split the sql file into batches of 250 statements and load them one at a time.
+# If wrangler ever gets fixed, we can remote this script.
+# - Keegan Smith 09/25
+
 if [ "$#" -ne 1 ]; then
     echo "Usage: $0 <root_directory>"
     exit 1
@@ -34,13 +41,13 @@ for ((i=0; i<TOTAL; i+=BATCH_SIZE)); do
             npx wrangler d1 execute DB --command="$stmt" --local --config "${WORKER_DIR}/wrangler.local.toml"
             EXIT_CODE=$?
             if [ $EXIT_CODE -ne 0 ]; then
-                echo "❌ Statement failed:"
+                echo "Statement failed to load:"
                 echo "$stmt"
                 exit $EXIT_CODE
             fi
         done
     fi
 done
-echo "✅ All statements executed successfully."
+echo "All statements executed successfully."
 
 

--- a/bin/load_entities.sh
+++ b/bin/load_entities.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <root_directory>"
+    exit 1
+fi
+
+ROOT_DIR="$1"
+DATA_DIR="${ROOT_DIR}/data"
+WORKER_DIR="${ROOT_DIR}/workers-api"
+SQL_FILE="${DATA_DIR}/data/db.sql"
+
+# Number of statements per batch
+BATCH_SIZE=250
+
+# Read SQL file into an array (one line per statement)
+mapfile -t STATEMENTS < "$SQL_FILE"
+
+TOTAL=${#STATEMENTS[@]}
+echo "Loaded $TOTAL statements from $SQL_FILE"
+
+# Process in batches
+for ((i=0; i<TOTAL; i+=BATCH_SIZE)); do
+    CHUNK=("${STATEMENTS[@]:i:BATCH_SIZE}")
+    SQL_CHUNK=$(printf "%s\n" "${CHUNK[@]}")
+
+    echo "Executing statements $((i+1)) to $((i+${#CHUNK[@]}))..."
+    npx wrangler d1 execute DB --command="$SQL_CHUNK" --local --config "${WORKER_DIR}/wrangler.local.toml"
+    EXIT_CODE=$?
+
+    if [ $EXIT_CODE -ne 0 ]; then
+        echo "⚠ Batch failed. Debugging statement by statement..."
+        for stmt in "${CHUNK[@]}"; do
+            npx wrangler d1 execute DB --command="$stmt" --local --config "${WORKER_DIR}/wrangler.local.toml"
+            EXIT_CODE=$?
+            if [ $EXIT_CODE -ne 0 ]; then
+                echo "❌ Statement failed:"
+                echo "$stmt"
+                exit $EXIT_CODE
+            fi
+        done
+    fi
+done
+echo "✅ All statements executed successfully."
+
+

--- a/dashboard/src/components/common/BrandBadge.tsx
+++ b/dashboard/src/components/common/BrandBadge.tsx
@@ -43,6 +43,7 @@ const BrandBadge = ({ name, imageSrc, isMultiLine, ...rest }: BrandBadgeProps) =
       whiteSpace: "nowrap",
     };
   }
+  console.log(`HERE: ${name} || ${imageSrc}`); // TODO: remove
 
   return (
     <HStack {...rest}>

--- a/dashboard/src/components/common/BrandBadge.tsx
+++ b/dashboard/src/components/common/BrandBadge.tsx
@@ -43,7 +43,6 @@ const BrandBadge = ({ name, imageSrc, isMultiLine, ...rest }: BrandBadgeProps) =
       whiteSpace: "nowrap",
     };
   }
-  console.log(`HERE: ${name} || ${imageSrc}`); // TODO: remove
 
   return (
     <HStack {...rest}>

--- a/dashboard/src/components/common/SocialCard.tsx
+++ b/dashboard/src/components/common/SocialCard.tsx
@@ -15,7 +15,7 @@
 // Author: James Diprose
 
 import { DonutSparkline } from "@/components/charts";
-import { cokiImageLoader } from "@/lib/api";
+import { entityImageLoader } from "@/lib/api";
 import { Entity } from "@/lib/model";
 import { toCompactNumber } from "@/lib/utils";
 import { Box, BoxProps, Flex, HStack, Image, StackProps, Text, VStack } from "@chakra-ui/react";
@@ -65,7 +65,7 @@ const SocialCard = ({ entity, ...rest }: ShareCardProps) => {
           rounded="48px"
           objectFit="cover"
           boxSize={{ base: "532px" }}
-          src={cokiImageLoader(entity.logo_lg)}
+          src={entityImageLoader(entity, "lg")}
           alt={entity.name}
           style={{
             filter: "drop-shadow( 0px 0px 12px rgba(0, 0, 0, .3))",

--- a/dashboard/src/components/dashboard/Dashboard.tsx
+++ b/dashboard/src/components/dashboard/Dashboard.tsx
@@ -518,7 +518,6 @@ export async function getDashboardStaticProps() {
   const countryQuery = queryFormToQueryParams(makeFormValues(stats.country, DEFAULT_N_OUTPUTS));
   const countries = (await client.getEntities("country", countryQuery)).data;
   const institutionQuery = queryFormToQueryParams(makeFormValues(stats.institution, DEFAULT_N_OUTPUTS));
-  console.log(institutionQuery);
   const institutions = (await client.getEntities("institution", institutionQuery)).data;
 
   return {

--- a/dashboard/src/components/dashboard/Dashboard.tsx
+++ b/dashboard/src/components/dashboard/Dashboard.tsx
@@ -18,7 +18,7 @@ import { Breadcrumbs, Head, Icon, PageLoader, TextCollapse } from "@/components/
 import { FilterForm, institutionTypes, OpenAccess, QueryForm } from "@/components/filter";
 import { Node } from "@/components/common/CheckboxTree";
 import { IndexTable } from "@/components/table";
-import { cokiImageLoader, OADataAPI } from "@/lib/api";
+import { entityImageLoader, OADataAPI } from "@/lib/api";
 import { useEffectAfterRender } from "@/lib/hooks";
 import { Entity, EntityStats, QueryParams, QueryResult, Stats } from "@/lib/model";
 import {
@@ -322,10 +322,10 @@ const Dashboard = ({ defaultEntityType, defaultCountries, defaultInstitutions, s
       <Head title={title} description={description}>
         {/* Preload the first page of country and institution logos */}
         {defaultCountries.items.map((e: Entity) => (
-          <link key={`${e.id}-logo-sm-preload`} rel="preload" href={cokiImageLoader(e.logo_sm)} as="image" />
+          <link key={`${e.id}-logo-sm-preload`} rel="preload" href={entityImageLoader(e, "sm")} as="image" />
         ))}
         {defaultInstitutions.items.map((e: Entity) => (
-          <link key={`${e.id}-logo-sm-preload`} rel="preload" href={cokiImageLoader(e.logo_sm)} as="image" />
+          <link key={`${e.id}-logo-sm-preload`} rel="preload" href={entityImageLoader(e, "sm")} as="image" />
         ))}
       </Head>
 
@@ -518,6 +518,7 @@ export async function getDashboardStaticProps() {
   const countryQuery = queryFormToQueryParams(makeFormValues(stats.country, DEFAULT_N_OUTPUTS));
   const countries = (await client.getEntities("country", countryQuery)).data;
   const institutionQuery = queryFormToQueryParams(makeFormValues(stats.institution, DEFAULT_N_OUTPUTS));
+  console.log(institutionQuery);
   const institutions = (await client.getEntities("institution", institutionQuery)).data;
 
   return {

--- a/dashboard/src/components/details/EntityDetails.tsx
+++ b/dashboard/src/components/details/EntityDetails.tsx
@@ -25,7 +25,7 @@ import {
   PublisherOpenCard,
   SummaryCard,
 } from "@/components/details";
-import { cokiImageLoader, makeSocialCardUrl } from "@/lib/api";
+import { entityImageLoader, makeSocialCardUrl } from "@/lib/api";
 import { Entity, Stats } from "@/lib/model";
 import { Box, Flex, VStack } from "@chakra-ui/react";
 import lodashGet from "lodash.get";
@@ -83,7 +83,7 @@ export const EntityDetails = ({ entity, stats, ...rest }: EntityDetailsProps) =>
         shareImageType="image/jpeg"
       >
         {/* Preload the entity logo */}
-        <link rel="preload" href={cokiImageLoader(entity.logo_md)} as="image" />
+        <link rel="preload" href={entityImageLoader(entity, "md")} as="image" />
       </Head>
 
       <Breadcrumbs

--- a/dashboard/src/components/details/Header.tsx
+++ b/dashboard/src/components/details/Header.tsx
@@ -16,7 +16,7 @@
 
 import { TextCollapse } from "@/components/common";
 import { makeDescription, SharePopover } from "@/components/details";
-import { cokiImageLoader } from "@/lib/api";
+import { entityImageLoader } from "@/lib/api";
 import { Entity } from "@/lib/model";
 import { Box, Flex, HStack, Image, StackProps, Text, VStack } from "@chakra-ui/react";
 import React, { memo } from "react";
@@ -60,7 +60,7 @@ const Header = ({ entity, ...rest }: EntityHeaderProps) => {
               rounded="full"
               objectFit="cover"
               boxSize={{ base: "60px", md: "100px" }}
-              src={cokiImageLoader(entity.logo_md)}
+              src={entityImageLoader(entity, "md")}
               alt={entity.name}
               style={{
                 filter: "drop-shadow( 0px 0px 10px rgba(0, 0, 0, .2))",

--- a/dashboard/src/components/search/SearchResult.tsx
+++ b/dashboard/src/components/search/SearchResult.tsx
@@ -15,7 +15,7 @@
 // Author: James Diprose
 
 import { BrandBadge, Link } from "@/components/common";
-import { cokiImageLoader } from "@/lib/api";
+import { entityImageLoader } from "@/lib/api";
 import { Entity } from "@/lib/model";
 import { Box, BoxProps, HStack, Image, Text } from "@chakra-ui/react";
 import React, { memo } from "react";
@@ -29,7 +29,7 @@ const SearchResult = ({ entity, onClick, ...rest }: SearchResultProps) => {
   return (
     <Box key={entity.id} textStyle="tableCell" data-test={entity.id} {...rest}>
       <Link href={`/${entity.entity_type}/${entity.id}`} onClick={onClick}>
-        <BrandBadge name={entity.name} imageSrc={cokiImageLoader(entity.logo_sm)} my="16px" />
+        <BrandBadge name={entity.name} imageSrc={entityImageLoader(entity, "sm")} my="16px" />
       </Link>
     </Box>
   );

--- a/dashboard/src/components/table/EntityCell.tsx
+++ b/dashboard/src/components/table/EntityCell.tsx
@@ -16,14 +16,14 @@
 
 import { BrandBadge, Link } from "@/components/common";
 import { EntityProps, makeHref } from "@/components/table";
-import { cokiImageLoader } from "@/lib/api";
+import { entityImageLoader } from "@/lib/api";
 import React, { memo } from "react";
 
 function EntityCell({ entity }: EntityProps) {
   const href = makeHref(entity.entity_type, entity.id);
   return (
     <Link href={href}>
-      <BrandBadge name={entity.name} imageSrc={cokiImageLoader(entity.logo_sm)} isMultiLine />
+      <BrandBadge name={entity.name} imageSrc={entityImageLoader(entity, "sm")} isMultiLine />
     </Link>
   );
 }

--- a/dashboard/src/layouts/Footer.tsx
+++ b/dashboard/src/layouts/Footer.tsx
@@ -144,7 +144,7 @@ const FooterLinks = ({ links, ...rest }: FooterLinksProps) => {
 const FooterCredits = ({ ...rest }: StackProps) => {
   return (
     <VStack align="left" textStyle="footerLink2" color={{ base: "grey.900", std: "grey.100" }} {...rest}>
-      <Link href="https://clearbit.com/">Company Logos by Clearbit</Link>
+      <Link href="https://logo.dev">Company Logos by logo.dev</Link>
     </VStack>
   );
 };

--- a/dashboard/src/lib/api.spec.ts
+++ b/dashboard/src/lib/api.spec.ts
@@ -1,5 +1,6 @@
 import {
   cokiImageLoader,
+  getDomain,
   makeDownloadDataUrl,
   makeEntityUrl,
   makeFilterUrl,
@@ -76,4 +77,38 @@ test("test makeSocialCardUrl", () => {
 test("test cokiImageLoader", () => {
   const url = cokiImageLoader("path/to/image.jpg");
   expect(url).toEqual(`${IMAGES_HOST}/path/to/image.jpg`);
+});
+
+describe("getDomain", () => {
+  test("should correctly extract the domain from a valid URL", () => {
+    // Test a standard URL with 'www.'
+    let domain = getDomain("http://www.guc-asic.com/en-global");
+    expect(domain).toBe("guc-asic.com");
+
+    // Test a URL without 'www.'
+    domain = getDomain("https://example.com/path/to/page");
+    expect(domain).toBe("example.com");
+
+    // Test a different protocol like FTP
+    domain = getDomain("ftp://ftp.server.org/file.zip");
+    expect(domain).toBe("ftp.server.org");
+
+    // Test a URL with a subdomain
+    domain = getDomain("https://sub.domain.co.uk");
+    expect(domain).toBe("sub.domain.co.uk");
+  });
+
+  test("should return null for invalid or malformed URLs", () => {
+    // Test a completely invalid string
+    let domain = getDomain("this is not a url");
+    expect(domain).toBeNull();
+
+    // Test an empty string
+    domain = getDomain("");
+    expect(domain).toBeNull();
+
+    // Test a URL with no protocol
+    domain = getDomain("www.test.com");
+    expect(domain).toBe("test.com");
+  });
 });

--- a/dashboard/src/lib/api.spec.ts
+++ b/dashboard/src/lib/api.spec.ts
@@ -1,6 +1,5 @@
 import {
   cokiImageLoader,
-  getDomain,
   makeDownloadDataUrl,
   makeEntityUrl,
   makeFilterUrl,
@@ -77,38 +76,4 @@ test("test makeSocialCardUrl", () => {
 test("test cokiImageLoader", () => {
   const url = cokiImageLoader("path/to/image.jpg");
   expect(url).toEqual(`${IMAGES_HOST}/path/to/image.jpg`);
-});
-
-describe("getDomain", () => {
-  test("should correctly extract the domain from a valid URL", () => {
-    // Test a standard URL with 'www.'
-    let domain = getDomain("http://www.guc-asic.com/en-global");
-    expect(domain).toBe("guc-asic.com");
-
-    // Test a URL without 'www.'
-    domain = getDomain("https://example.com/path/to/page");
-    expect(domain).toBe("example.com");
-
-    // Test a different protocol like FTP
-    domain = getDomain("ftp://ftp.server.org/file.zip");
-    expect(domain).toBe("ftp.server.org");
-
-    // Test a URL with a subdomain
-    domain = getDomain("https://sub.domain.co.uk");
-    expect(domain).toBe("sub.domain.co.uk");
-  });
-
-  test("should return null for invalid or malformed URLs", () => {
-    // Test a completely invalid string
-    let domain = getDomain("this is not a url");
-    expect(domain).toBeNull();
-
-    // Test an empty string
-    domain = getDomain("");
-    expect(domain).toBeNull();
-
-    // Test a URL with no protocol
-    domain = getDomain("www.test.com");
-    expect(domain).toBe("test.com");
-  });
 });

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -266,85 +266,12 @@ export function entityImageLoader(entity: Entity, size: "sm" | "md" | "lg") {
         return cokiImageLoader(entity.logo_sm);
     }
   }
-  return logoImageLoader(entity.url, size);
+
+  return `${API_HOST}/logos/${entity.id}?size=${size}`;
 }
 
 export function cokiImageLoader(src: string) {
   return `${IMAGES_HOST}/${src}`;
-}
-
-/**
- * Takes a URL string and returns the domain.
- * @param url The url associated with the institution
- * @returns The logo url
- **/
-export function logoImageLoader(url: string, size: "sm" | "md" | "lg"): string {
-  if (url === null) {
-    console.log("null url provided");
-  }
-  let sizePx;
-  switch (size) {
-    case "md":
-      sizePx = "128";
-    case "lg":
-      sizePx = "512";
-    default:
-      sizePx = "32";
-  }
-  let logoUrl;
-  const domainUrl = getDomain(url);
-  if (typeof domainUrl !== "string") {
-    logoUrl = `${IMAGES_HOST}/unknown.svg`;
-  } else {
-    logoUrl = `${LOGOS_HOST}/${getDomain(url)}?token=${LOGOS_API_TOKEN}&size=${sizePx}`;
-  }
-  console.log(logoUrl);
-  return logoUrl;
-}
-
-/**
- * Takes a URL string and returns the domain.
- * @param url The URL string to process.
- * @returns The domain name (e.g., "guc-asic.com") or null if the URL is invalid.
- */
-// export function getDomain(url: string): string | null {
-//   try {
-//     const parsedUrl = new URL(url);
-//     const hostname = parsedUrl.hostname;
-//     // Remove "www." prefix if it exists
-//     return hostname.startsWith("www.") ? hostname.substring(4) : hostname;
-//   } catch (error) {
-//     // Return null for malformed or invalid URLs
-//     console.error(`Invalid URL provided: ${url}: ${error}`);
-//     return null;
-//   }
-// }
-
-/**
- * Takes a URL string and returns the domain.
- * It is idempotent.
- * @param url The URL string to process.
- * @returns The domain name (e.g., "guc-asic.com") or null if the URL is invalid.
- */
-export function getDomain(url: string): string | null {
-  try {
-    let validatedUrl = url;
-    // Check if the URL starts with a protocol
-    if (!url.match(/^[a-z]+:\/\//i)) {
-      // If no protocol is found, prepend 'https://'
-      validatedUrl = `https://${url}`;
-    }
-
-    const parsedUrl = new URL(validatedUrl);
-    const hostname = parsedUrl.hostname;
-
-    // Remove "www." prefix if it exists
-    return hostname.startsWith("www.") ? hostname.substring(4) : hostname;
-  } catch (error) {
-    // Return null for malformed or invalid URLs
-    console.error(`Invalid URL provided: ${url}`);
-    return null;
-  }
 }
 
 export function idsToStaticPaths(ids: Array<string>, entityType?: string) {

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -26,6 +26,8 @@ import statsRaw from "@data/data/stats.json";
 
 export const API_HOST = process.env.COKI_API_URL || "https://api.coki.ac";
 export const IMAGES_HOST = process.env.COKI_IMAGES_URL || "https://images.open.coki.ac";
+export const LOGOS_HOST = "https://img.logo.dev";
+export const LOGOS_API_TOKEN = process.env.LOGOS_API_TOKEN || "";
 
 export class OADataAPI {
   host: string;
@@ -71,7 +73,8 @@ export class OADataAPI {
     if (controller != null) {
       options.signal = controller.signal;
     }
-    return this.api.get(url, options);
+    const apiReturn = this.api.get(url, options);
+    return apiReturn;
   }
 
   async searchEntities(
@@ -244,6 +247,7 @@ export function makeDownloadDataUrl(host: string, entityType: string, id: string
 }
 
 export function makeSocialCardUrl(entityId: string): string {
+  // FIX: fix URL
   const url = new URL(`${IMAGES_HOST}/social-cards/${entityId}.jpg`);
   const params = new URLSearchParams();
   params.append("build", BUILD_ID);
@@ -251,8 +255,96 @@ export function makeSocialCardUrl(entityId: string): string {
   return url.toString();
 }
 
+export function entityImageLoader(entity: Entity, size: "sm" | "md" | "lg") {
+  if (entity.entity_type == "country") {
+    switch (size) {
+      case "md":
+        return cokiImageLoader(entity.logo_md);
+      case "lg":
+        return cokiImageLoader(entity.logo_lg);
+      default:
+        return cokiImageLoader(entity.logo_sm);
+    }
+  }
+  return logoImageLoader(entity.url, size);
+}
+
 export function cokiImageLoader(src: string) {
   return `${IMAGES_HOST}/${src}`;
+}
+
+/**
+ * Takes a URL string and returns the domain.
+ * @param url The url associated with the institution
+ * @returns The logo url
+ **/
+export function logoImageLoader(url: string, size: "sm" | "md" | "lg"): string {
+  if (url === null) {
+    console.log("null url provided");
+  }
+  let sizePx;
+  switch (size) {
+    case "md":
+      sizePx = "128";
+    case "lg":
+      sizePx = "512";
+    default:
+      sizePx = "32";
+  }
+  let logoUrl;
+  const domainUrl = getDomain(url);
+  if (typeof domainUrl !== "string") {
+    logoUrl = `${IMAGES_HOST}/unknown.svg`;
+  } else {
+    logoUrl = `${LOGOS_HOST}/${getDomain(url)}?token=${LOGOS_API_TOKEN}&size=${sizePx}`;
+  }
+  console.log(logoUrl);
+  return logoUrl;
+}
+
+/**
+ * Takes a URL string and returns the domain.
+ * @param url The URL string to process.
+ * @returns The domain name (e.g., "guc-asic.com") or null if the URL is invalid.
+ */
+// export function getDomain(url: string): string | null {
+//   try {
+//     const parsedUrl = new URL(url);
+//     const hostname = parsedUrl.hostname;
+//     // Remove "www." prefix if it exists
+//     return hostname.startsWith("www.") ? hostname.substring(4) : hostname;
+//   } catch (error) {
+//     // Return null for malformed or invalid URLs
+//     console.error(`Invalid URL provided: ${url}: ${error}`);
+//     return null;
+//   }
+// }
+
+/**
+ * Takes a URL string and returns the domain.
+ * It is idempotent.
+ * @param url The URL string to process.
+ * @returns The domain name (e.g., "guc-asic.com") or null if the URL is invalid.
+ */
+export function getDomain(url: string): string | null {
+  try {
+    let validatedUrl = url;
+    // Check if the URL starts with a protocol
+    if (!url.match(/^[a-z]+:\/\//i)) {
+      // If no protocol is found, prepend 'https://'
+      validatedUrl = `https://${url}`;
+    }
+
+    const parsedUrl = new URL(validatedUrl);
+    const hostname = parsedUrl.hostname;
+
+    // Remove "www." prefix if it exists
+    return hostname.startsWith("www.") ? hostname.substring(4) : hostname;
+  } catch (error) {
+    // Return null for malformed or invalid URLs
+    console.error(`Invalid URL provided: ${url}`);
+    return null;
+  }
 }
 
 export function idsToStaticPaths(ids: Array<string>, entityType?: string) {

--- a/dashboard/src/pages/[entityType]/[id].tsx
+++ b/dashboard/src/pages/[entityType]/[id].tsx
@@ -52,6 +52,7 @@ export async function getStaticProps({ params }: Params) {
   // Validate institution ID
   // ROR ID pattern: https://ror.readme.io/docs/ror-identifier-pattern
   if (params.entityType === "institution" && !/^0[a-hj-km-np-tv-z|0-9]{6}[0-9]{2}$/.test(params.id)) {
+    console.log(`invalid institution ID: ${params.id}`);
     return { notFound: true };
   }
 
@@ -60,6 +61,7 @@ export async function getStaticProps({ params }: Params) {
   const client = new OADataAPI();
   const entity = await client.getEntity(params.entityType, params.id);
   if (entity === null) {
+    console.log(`Entity not found: ${params.id}`);
     return { notFound: true };
   }
 

--- a/dashboard/src/pages/cards/[entityType]/[id].tsx
+++ b/dashboard/src/pages/cards/[entityType]/[id].tsx
@@ -40,6 +40,9 @@ export async function getStaticProps({ params }: Params) {
     if (entity === null) {
       return { notFound: true };
     }
+    if (entity.url === null) {
+      console.log("null url found at getStaticProps");
+    }
 
     return {
       props: {
@@ -63,7 +66,6 @@ export async function getStaticPaths() {
       "institution",
     );
     const paths = countryPaths.concat(institutionPaths);
-
     return {
       paths: paths,
       fallback: false,

--- a/workers-api/package.json
+++ b/workers-api/package.json
@@ -34,7 +34,7 @@
     "typescript": "^5.3.3",
     "vitest": "^0.33.0",
     "vitest-environment-miniflare": "^2.14.2",
-    "wrangler": "3.103.2"
+    "wrangler": "4.20.0"
   },
   "dependencies": {
     "@json2csv/plainjs": "7.0.5",

--- a/workers-api/src/database.ts
+++ b/workers-api/src/database.ts
@@ -68,17 +68,17 @@ const PROPERTIES_TO_DELETE = [
 // entity_fts5
 
 // The Miniflare V2 db.exec doesn't parse SQL very well, hence the lack of newlines and comments
-const SCHEMA = `DROP TABLE IF EXISTS entity;
+const ENTITY_SCHEMA = `DROP TABLE IF EXISTS entity;
 DROP TABLE IF EXISTS entity_fts5;
-CREATE TABLE entity (id INTEGER PRIMARY KEY AUTOINCREMENT, entity_id TEXT NOT NULL, entity_type TEXT NOT NULL, name TEXT NOT NULL, name_ascii_folded TEXT NOT NULL, acronyms TEXT, logo_sm TEXT NOT NULL, subregion TEXT NOT NULL, region TEXT NOT NULL, country_code INTEGER, country_name TEXT, institution_type TEXT, n_outputs INT NOT NULL, n_outputs_open INT NOT NULL, n_outputs_black INT NOT NULL, p_outputs_open FLOAT NOT NULL, p_outputs_publisher_open_only FLOAT NOT NULL, p_outputs_both FLOAT NOT NULL, p_outputs_other_platform_open_only FLOAT NOT NULL, p_outputs_closed FLOAT NOT NULL, p_outputs_black FLOAT NOT NULL, search_weight FLOAT NOT NULL, search_country_region_weight FLOAT NOT NULL, search_inst_country_weight FLOAT NOT NULL);
+CREATE TABLE entity (id INTEGER PRIMARY KEY AUTOINCREMENT, entity_id TEXT NOT NULL, entity_type TEXT NOT NULL, name TEXT NOT NULL, name_ascii_folded TEXT NOT NULL, acronyms TEXT, logo_sm TEXT, url TEXT, subregion TEXT NOT NULL, region TEXT NOT NULL, country_code INTEGER, country_name TEXT, institution_type TEXT, n_outputs INT NOT NULL, n_outputs_open INT NOT NULL, n_outputs_black INT NOT NULL, p_outputs_open FLOAT NOT NULL, p_outputs_publisher_open_only FLOAT NOT NULL, p_outputs_both FLOAT NOT NULL, p_outputs_other_platform_open_only FLOAT NOT NULL, p_outputs_closed FLOAT NOT NULL, p_outputs_black FLOAT NOT NULL, search_weight FLOAT NOT NULL, search_country_region_weight FLOAT NOT NULL, search_inst_country_weight FLOAT NOT NULL);
+CREATE VIRTUAL TABLE entity_fts5 USING fts5(name, acronyms, region, country_name, entity_type, content='none', tokenize='porter unicode61 remove_diacritics 1');
 CREATE INDEX idx_entity_entity_type ON entity(entity_type);
 CREATE INDEX idx_entity_name ON entity(name);
 CREATE INDEX idx_entity_name_ascii_folded ON entity(name_ascii_folded);
 CREATE INDEX idx_entity_n_outputs ON entity(n_outputs);
 CREATE INDEX idx_entity_n_outputs_open ON entity(n_outputs_open);
 CREATE INDEX idx_entity_p_outputs_open ON entity(p_outputs_open);
-CREATE INDEX idx_entity_filter ON entity(entity_type, n_outputs, n_outputs_open, p_outputs_open, subregion, institution_type);
-CREATE VIRTUAL TABLE entity_fts5 USING fts5(name, acronyms, region, country_name, entity_type, content='none', tokenize='porter unicode61 remove_diacritics 1');`;
+CREATE INDEX idx_entity_filter ON entity(entity_type, n_outputs, n_outputs_open, p_outputs_open, subregion, institution_type);`;
 
 /*
 TODO: optimise indexes when adding more entities
@@ -138,7 +138,7 @@ function escapeSingleQuotes(text: string): string {
 
 export function entitiesToSQL(entities: Array<Entity>) {
   // Add schema
-  const rows = [SCHEMA];
+  const rows = [ENTITY_SCHEMA];
 
   // Find max outputs for institutions in each country
   const instCountryMaxOutputs: { [key: string]: number } = {};
@@ -211,6 +211,7 @@ export function entitiesToSQL(entities: Array<Entity>) {
       name_ascii_folded,
       acronyms,
       entity.logo_sm,
+      entity.url,
       entity.subregion,
       entity.region,
       country_code,

--- a/workers-api/src/handlers.test.ts
+++ b/workers-api/src/handlers.test.ts
@@ -15,7 +15,7 @@
 // Author: James Diprose
 
 import { expect, test, describe } from "vitest";
-import { parseQuery } from "@/handlers";
+import { parseQuery, getDomain } from "@/handlers";
 
 describe("parseQuery", () => {
   test("test default values", () => {
@@ -128,5 +128,39 @@ describe("parseQuery", () => {
     };
     const settings = parseQuery(input);
     expect(settings).toMatchObject(expected);
+  });
+});
+
+describe("getDomain", () => {
+  test("should correctly extract the domain from a valid URL", () => {
+    // Test a standard URL with 'www.'
+    let domain = getDomain("http://www.guc-asic.com/en-global");
+    expect(domain).toBe("guc-asic.com");
+
+    // Test a URL without 'www.'
+    domain = getDomain("https://example.com/path/to/page");
+    expect(domain).toBe("example.com");
+
+    // Test a different protocol like FTP
+    domain = getDomain("ftp://ftp.server.org/file.zip");
+    expect(domain).toBe("ftp.server.org");
+
+    // Test a URL with a subdomain
+    domain = getDomain("https://sub.domain.co.uk");
+    expect(domain).toBe("sub.domain.co.uk");
+  });
+
+  test("should return null for invalid or malformed URLs", () => {
+    // Test a completely invalid string
+    let domain = getDomain("this is not a url");
+    expect(domain).toBeNull();
+
+    // Test an empty string
+    domain = getDomain("");
+    expect(domain).toBeNull();
+
+    // Test a URL with no protocol
+    domain = getDomain("www.test.com");
+    expect(domain).toBe("test.com");
   });
 });

--- a/workers-api/src/handlers.ts
+++ b/workers-api/src/handlers.ts
@@ -209,6 +209,7 @@ export const searchHandler = async (
   });
 };
 
+// Fetches a logo from the external LOGO API source
 export const fetchLogoHandler = async (
   { params, query }: FetchImageParams,
   env: Bindings,
@@ -265,6 +266,7 @@ export const fetchLogoHandler = async (
     headers: headers,
   });
 };
+
 /** Helper function to convert a ReadableStream to string */
 async function streamToString(stream: ReadableStream<Uint8Array>) {
   const reader = stream.getReader();

--- a/workers-api/src/handlers.ts
+++ b/workers-api/src/handlers.ts
@@ -26,6 +26,7 @@ import {
   FilterRequest,
   Query,
   SearchRequest,
+  FetchImageParams,
 } from "@/types";
 import { filterEntities, searchEntities } from "@/database";
 
@@ -37,6 +38,7 @@ const MIN_LIMIT = 1;
 const MAX_LIMIT = 100;
 const MIN_OUTPUTS = 0;
 const MIN_OUTPUTS_OPEN = 0;
+const LOGOS_HOST = "https://img.logo.dev";
 
 export const fetchEntityHandler = async (
   req: EntityRequest,
@@ -161,6 +163,7 @@ export const filterEntitiesHandler = async (
 ) => {
   const q = req["query"];
   const query = parseQuery(q);
+  console.log(query);
 
   // Fetch data
   const results = await filterEntities(
@@ -205,6 +208,106 @@ export const searchHandler = async (
     headers: HEADERS,
   });
 };
+
+export const fetchLogoHandler = async (
+  { params, query }: FetchImageParams,
+  env: Bindings,
+) => {
+  const { entityId } = params;
+  const size = query.size;
+
+  let sizePx;
+  switch (size) {
+    case "md":
+      sizePx = "128";
+      break;
+    case "lg":
+      sizePx = "512";
+      break;
+    default:
+      sizePx = "32"; // default to small
+  }
+
+  // Fetch entity JSON from KV using fetchEntityHandler
+  const assetPath = `institution/${entityId}.json`;
+  const kvKey = JSON.parse(manifestJSON)[assetPath];
+  const entityDataStream = await env.__STATIC_CONTENT.get(kvKey, {
+    type: "stream",
+  });
+  if (!entityDataStream) {
+    return new Response("Entity not found", { status: 404 });
+  }
+
+  // Parse entity JSON minimally to get the domain
+  const entityJSON = await streamToString(entityDataStream);
+  const entity = JSON.parse(entityJSON);
+  const domain = getDomain(entity.url);
+
+  if (!domain) {
+    return new Response("Domain not found for entity", { status: 404 });
+  }
+
+  // Fetch the image using the domain
+  const headers = {
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "image/jpeg",
+  };
+
+  const res = await fetch(
+    `${LOGOS_HOST}/${domain}?token=${env.LOGOS_API_TOKEN}&size=${sizePx}`,
+  );
+  if (!res.ok) {
+    throw new Error(`Image fetch failed for domain ${domain}: ${res.status}`);
+  }
+
+  return new Response(res.body, {
+    status: res.status,
+    headers: headers,
+  });
+};
+/** Helper function to convert a ReadableStream to string */
+async function streamToString(stream: ReadableStream<Uint8Array>) {
+  const reader = stream.getReader();
+  let result = "";
+  const decoder = new TextDecoder();
+  let done = false;
+
+  while (!done) {
+    const { value, done: d } = await reader.read();
+    done = d;
+    if (value) result += decoder.decode(value, { stream: true });
+  }
+
+  result += decoder.decode(); // flush
+  return result;
+}
+
+/**
+ * Takes a URL string and returns the domain.
+ * It is idempotent.
+ * @param url The URL string to process.
+ * @returns The domain name (e.g., "guc-asic.com") or null if the URL is invalid.
+ */
+export function getDomain(url: string): string | null {
+  try {
+    let validatedUrl = url;
+    // Check if the URL starts with a protocol
+    if (!url.match(/^[a-z]+:\/\//i)) {
+      // If no protocol is found, prepend 'https://'
+      validatedUrl = `https://${url}`;
+    }
+
+    const parsedUrl = new URL(validatedUrl);
+    const hostname = parsedUrl.hostname;
+
+    // Remove "www." prefix if it exists
+    return hostname.startsWith("www.") ? hostname.substring(4) : hostname;
+  } catch (error) {
+    // Return null for malformed or invalid URLs
+    console.error(`Invalid URL provided: ${url}`);
+    return null;
+  }
+}
 
 export const downloadDataHandler = async (
   req: EntityRequest,

--- a/workers-api/src/index.ts
+++ b/workers-api/src/index.ts
@@ -16,14 +16,20 @@
 
 import { handleRequest } from "@/router";
 
-const maxAge = 604800; // cache data for 7 days
-
 export function makeCacheKey(request: Request): Request {
   return new Request(request.url, request);
 }
 
 //@ts-ignore
-export async function fetchData(request: Request, env: Bindings, ctx: ExecutionContext) {
+export async function fetchData(
+  request: Request,
+  env: Bindings,
+  ctx: ExecutionContext,
+) {
+  let maxAge = 604800; // cache data for 7 days
+  if (request.url.includes("/logos/")) {
+    maxAge = 2592000; // 30 days for logos
+  }
   const cache = caches.default;
   const cacheKey = makeCacheKey(request);
   let response = await cache.match(cacheKey);
@@ -36,7 +42,7 @@ export async function fetchData(request: Request, env: Bindings, ctx: ExecutionC
 
     if (response?.status === 200) {
       // If 200 code then cache response, else return error
-      response.headers.append("Cache-Control", `s-maxage=${maxAge}`);
+      response.headers.set("Cache-Control", `s-maxage=${maxAge}`);
       ctx.waitUntil(cache.put(cacheKey, response.clone()));
     }
   }

--- a/workers-api/src/router.ts
+++ b/workers-api/src/router.ts
@@ -15,13 +15,21 @@
 // Author: James Diprose
 
 import ittyRouter from "itty-router";
-import { filterEntitiesHandler, downloadDataHandler, fetchEntityHandler, searchHandler, HEADERS } from "@/handlers";
+import {
+  filterEntitiesHandler,
+  downloadDataHandler,
+  fetchEntityHandler,
+  fetchLogoHandler,
+  searchHandler,
+  HEADERS,
+} from "@/handlers";
 const { Router } = ittyRouter;
 
 // Setup API router
 export const router = Router({ base: "/" });
 router
   .get("/search/:text", searchHandler) // Search all countries and institutions with full text search
+  .get("/logos/:entityId", fetchLogoHandler) // Fetch institution image
   .get("/:entityType/:id", fetchEntityHandler) // Get the full details for a single country or institution
   .get("/countries", filterEntitiesHandler.bind(null, "country")) // Filter countries
   .get("/institutions", filterEntitiesHandler.bind(null, "institution")) // Filter institutions
@@ -35,6 +43,10 @@ router
       }),
   );
 
-export async function handleRequest(request: Request, env: Record<string, any>, ctx: ExecutionContext) {
+export async function handleRequest(
+  request: Request,
+  env: Record<string, any>,
+  ctx: ExecutionContext,
+) {
   return router.handle(request, env, ctx);
 }

--- a/workers-api/src/types.ts
+++ b/workers-api/src/types.ts
@@ -16,11 +16,21 @@
 
 import { Request, Obj } from "itty-router";
 
+export interface FetchImageParams {
+  params: {
+    entityId: string;
+  };
+  query: {
+    size?: "sm" | "md" | "lg"; // optional query param
+  };
+}
+
 export interface Entity extends Object {
   id: string;
   name: string;
   entity_type: string;
   logo_sm: string;
+  url: string;
   region: string;
   subregion: string;
   country_code?: string;

--- a/workers-api/types/bindings.d.ts
+++ b/workers-api/types/bindings.d.ts
@@ -7,4 +7,7 @@ interface Bindings {
 
   // D1 database
   __D1_BETA__DB: D1Database;
+
+  // Logo.dev API token
+  LOGOS_API_TOKEN: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2009,9 +2009,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-darwin-64@npm:1.20241230.0":
-  version: 1.20241230.0
-  resolution: "@cloudflare/workerd-darwin-64@npm:1.20241230.0"
+"@cloudflare/workerd-darwin-64@npm:1.20240925.0":
+  version: 1.20240925.0
+  resolution: "@cloudflare/workerd-darwin-64@npm:1.20240925.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -2030,9 +2030,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-darwin-arm64@npm:1.20241230.0":
-  version: 1.20241230.0
-  resolution: "@cloudflare/workerd-darwin-arm64@npm:1.20241230.0"
+"@cloudflare/workerd-darwin-arm64@npm:1.20240925.0":
+  version: 1.20240925.0
+  resolution: "@cloudflare/workerd-darwin-arm64@npm:1.20240925.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -2051,9 +2051,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-linux-64@npm:1.20241230.0":
-  version: 1.20241230.0
-  resolution: "@cloudflare/workerd-linux-64@npm:1.20241230.0"
+"@cloudflare/workerd-linux-64@npm:1.20240925.0":
+  version: 1.20240925.0
+  resolution: "@cloudflare/workerd-linux-64@npm:1.20240925.0"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
@@ -2072,9 +2072,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-linux-arm64@npm:1.20241230.0":
-  version: 1.20241230.0
-  resolution: "@cloudflare/workerd-linux-arm64@npm:1.20241230.0"
+"@cloudflare/workerd-linux-arm64@npm:1.20240925.0":
+  version: 1.20240925.0
+  resolution: "@cloudflare/workerd-linux-arm64@npm:1.20240925.0"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
@@ -2093,9 +2093,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-windows-64@npm:1.20241230.0":
-  version: 1.20241230.0
-  resolution: "@cloudflare/workerd-windows-64@npm:1.20241230.0"
+"@cloudflare/workerd-windows-64@npm:1.20240925.0":
+  version: 1.20240925.0
+  resolution: "@cloudflare/workerd-windows-64@npm:1.20240925.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2111,6 +2111,16 @@ __metadata:
   version: 1.20250816.0
   resolution: "@cloudflare/workerd-windows-64@npm:1.20250816.0"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@cloudflare/workers-shared@npm:0.5.4":
+  version: 0.5.4
+  resolution: "@cloudflare/workers-shared@npm:0.5.4"
+  dependencies:
+    mime: "npm:^3.0.0"
+    zod: "npm:^3.22.3"
+  checksum: 10/161600b627169048ae7fe7108363d8ef83e273db4f3fd0677ab296d444529e73662d192d3d841c09722f557a57295b738bddb2fc644a267968f7b57acef9e68b
   languageName: node
   linkType: hard
 
@@ -2364,7 +2374,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild-plugins/node-globals-polyfill@npm:0.2.3":
+"@esbuild-plugins/node-globals-polyfill@npm:0.2.3, @esbuild-plugins/node-globals-polyfill@npm:^0.2.3":
   version: 0.2.3
   resolution: "@esbuild-plugins/node-globals-polyfill@npm:0.2.3"
   peerDependencies:
@@ -2373,7 +2383,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild-plugins/node-modules-polyfill@npm:0.2.2":
+"@esbuild-plugins/node-modules-polyfill@npm:0.2.2, @esbuild-plugins/node-modules-polyfill@npm:^0.2.2":
   version: 0.2.2
   resolution: "@esbuild-plugins/node-modules-polyfill@npm:0.2.2"
   dependencies:
@@ -5516,6 +5526,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node-forge@npm:^1.3.0":
+  version: 1.3.14
+  resolution: "@types/node-forge@npm:1.3.14"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/500ce72435285fca145837da079b49a09a5bdf8391b0effc3eb2455783dd81ab129e574a36e1a0374a4823d889d5328177ebfd6fe45b432c0c43d48d790fe39c
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*":
   version: 24.3.0
   resolution: "@types/node@npm:24.3.0"
@@ -6413,7 +6432,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"anymatch@npm:^3.0.3":
+"anymatch@npm:^3.0.3, anymatch@npm:~3.1.2":
   version: 3.1.3
   resolution: "anymatch@npm:3.1.3"
   dependencies:
@@ -6891,6 +6910,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"binary-extensions@npm:^2.0.0":
+  version: 2.3.0
+  resolution: "binary-extensions@npm:2.3.0"
+  checksum: 10/bcad01494e8a9283abf18c1b967af65ee79b0c6a9e6fcfafebfe91dbe6e0fc7272bafb73389e198b310516ae04f7ad17d79aacf6cb4c0d5d5202a7e2e52c7d98
+  languageName: node
+  linkType: hard
+
 "bindings@npm:^1.4.0, bindings@npm:^1.5.0":
   version: 1.5.0
   resolution: "bindings@npm:1.5.0"
@@ -6921,7 +6947,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"blake3-wasm@npm:2.1.5":
+"blake3-wasm@npm:2.1.5, blake3-wasm@npm:^2.1.5":
   version: 2.1.5
   resolution: "blake3-wasm@npm:2.1.5"
   checksum: 10/7138aa209ac8411755ba07df7d035974886aac1fb4bb8cf710d354732037069bacc9984c19b3bc68bf5e17cc203f454cc9cfcb7115393aaf21ce865630dbf920
@@ -6954,7 +6980,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"braces@npm:^3.0.3":
+"braces@npm:^3.0.3, braces@npm:~3.0.2":
   version: 3.0.3
   resolution: "braces@npm:3.0.3"
   dependencies:
@@ -7227,6 +7253,25 @@ __metadata:
   dependencies:
     readdirp: "npm:^4.0.1"
   checksum: 10/e9a65db724a9ba2a40ad10f1d55caa5ccb5ba17533414271ec315004664860439348e51fa4faaa640fcc5f6427a410919fa1608892fbad41ed86fce682633cfa
+  languageName: node
+  linkType: hard
+
+"chokidar@npm:^3.5.3":
+  version: 3.6.0
+  resolution: "chokidar@npm:3.6.0"
+  dependencies:
+    anymatch: "npm:~3.1.2"
+    braces: "npm:~3.0.2"
+    fsevents: "npm:~2.3.2"
+    glob-parent: "npm:~5.1.2"
+    is-binary-path: "npm:~2.1.0"
+    is-glob: "npm:~4.0.1"
+    normalize-path: "npm:~3.0.0"
+    readdirp: "npm:~3.6.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: 10/c327fb07704443f8d15f7b4a7ce93b2f0bc0e6cea07ec28a7570aa22cd51fcf0379df589403976ea956c369f25aa82d84561947e227cd925902e1751371658df
   languageName: node
   linkType: hard
 
@@ -10587,7 +10632,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^5.1.2":
+"glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
@@ -11082,6 +11127,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-binary-path@npm:~2.1.0":
+  version: 2.1.0
+  resolution: "is-binary-path@npm:2.1.0"
+  dependencies:
+    binary-extensions: "npm:^2.0.0"
+  checksum: 10/078e51b4f956c2c5fd2b26bb2672c3ccf7e1faff38e0ebdba45612265f4e3d9fc3127a1fa8370bbf09eab61339203c3d3b7af5662cbf8be4030f8fac37745b0e
+  languageName: node
+  linkType: hard
+
 "is-boolean-object@npm:^1.2.1":
   version: 1.2.2
   resolution: "is-boolean-object@npm:1.2.2"
@@ -11187,7 +11241,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3":
+"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3, is-glob@npm:~4.0.1":
   version: 4.0.3
   resolution: "is-glob@npm:4.0.3"
   dependencies:
@@ -12743,9 +12797,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"miniflare@npm:3.20241230.2":
-  version: 3.20241230.2
-  resolution: "miniflare@npm:3.20241230.2"
+"miniflare@npm:3.20240925.0":
+  version: 3.20240925.0
+  resolution: "miniflare@npm:3.20240925.0"
   dependencies:
     "@cspotcode/source-map-support": "npm:0.8.1"
     acorn: "npm:^8.8.0"
@@ -12755,13 +12809,13 @@ __metadata:
     glob-to-regexp: "npm:^0.4.1"
     stoppable: "npm:^1.1.0"
     undici: "npm:^5.28.4"
-    workerd: "npm:1.20241230.0"
-    ws: "npm:^8.18.0"
+    workerd: "npm:1.20240925.0"
+    ws: "npm:^8.17.1"
     youch: "npm:^3.2.2"
     zod: "npm:^3.22.3"
   bin:
     miniflare: bootstrap.js
-  checksum: 10/c09e0c1f549a09976cf0bd92a2088a275a420da40eb4403756a260cd3efd3abd7ce6b9278ebffeababbf2f814a7defd0e9e2b704d4b342bb980f2fcc152f8699
+  checksum: 10/d5003262fc82b794b00893367eb4a337f4e04c6918c518569913c47b5ffbc21a18018db2450a319b359d6416b2ad08ce920cbb1243a49977538a304877fa3269
   languageName: node
   linkType: hard
 
@@ -12958,7 +13012,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mlly@npm:^1.4.0, mlly@npm:^1.7.3, mlly@npm:^1.7.4":
+"mlly@npm:^1.4.0, mlly@npm:^1.7.4":
   version: 1.7.4
   resolution: "mlly@npm:1.7.4"
   dependencies:
@@ -13007,7 +13061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11, nanoid@npm:^3.3.6, nanoid@npm:^3.3.7":
+"nanoid@npm:^3.3.11, nanoid@npm:^3.3.3, nanoid@npm:^3.3.6, nanoid@npm:^3.3.7":
   version: 3.3.11
   resolution: "nanoid@npm:3.3.11"
   bin:
@@ -13176,6 +13230,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-forge@npm:^1":
+  version: 1.3.1
+  resolution: "node-forge@npm:1.3.1"
+  checksum: 10/05bab6868633bf9ad4c3b1dd50ec501c22ffd69f556cdf169a00998ca1d03e8107a6032ba013852f202035372021b845603aeccd7dfcb58cdb7430013b3daa8d
+  languageName: node
+  linkType: hard
+
 "node-gyp-build@npm:^4.2.2":
   version: 4.8.4
   resolution: "node-gyp-build@npm:4.8.4"
@@ -13255,7 +13316,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-path@npm:^3.0.0":
+"normalize-path@npm:^3.0.0, normalize-path@npm:~3.0.0":
   version: 3.0.0
   resolution: "normalize-path@npm:3.0.0"
   checksum: 10/88eeb4da891e10b1318c4b2476b6e2ecbeb5ff97d946815ffea7794c31a89017c70d7f34b3c2ebf23ef4e9fc9fb99f7dffe36da22011b5b5c6ffa34f4873ec20
@@ -13694,7 +13755,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp-updated@npm:path-to-regexp@6.3.0, path-to-regexp@npm:6.3.0":
+"path-to-regexp-updated@npm:path-to-regexp@6.3.0, path-to-regexp@npm:6.3.0, path-to-regexp@npm:^6.3.0":
   version: 6.3.0
   resolution: "path-to-regexp@npm:6.3.0"
   checksum: 10/6822f686f01556d99538b350722ef761541ec0ce95ca40ce4c29e20a5b492fe8361961f57993c71b2418de12e604478dcf7c430de34b2c31a688363a7a944d9c
@@ -13766,7 +13827,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10/60c2595003b05e4535394d1da94850f5372c9427ca4413b71210f437f7b2ca091dbd611c45e8b37d10036fa8eade25c1b8951654f9d3973bfa66a2ff4d3b08bc
@@ -14476,6 +14537,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"readdirp@npm:~3.6.0":
+  version: 3.6.0
+  resolution: "readdirp@npm:3.6.0"
+  dependencies:
+    picomatch: "npm:^2.2.1"
+  checksum: 10/196b30ef6ccf9b6e18c4e1724b7334f72a093d011a99f3b5920470f0b3406a51770867b3e1ae9711f227ef7a7065982f6ee2ce316746b2cb42c88efe44297fe7
+  languageName: node
+  linkType: hard
+
 "redent@npm:^3.0.0":
   version: 3.0.0
   resolution: "redent@npm:3.0.0"
@@ -14615,14 +14685,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve.exports@npm:^2.0.0":
+"resolve.exports@npm:^2.0.0, resolve.exports@npm:^2.0.2":
   version: 2.0.3
   resolution: "resolve.exports@npm:2.0.3"
   checksum: 10/536efee0f30a10fac8604e6cdc7844dbc3f4313568d09f06db4f7ed8a5b8aeb8585966fe975083d1f2dfbc87cf5f8bc7ab65a5c23385c14acbb535ca79f8398a
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.10, resolve@npm:^1.22.4":
+"resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.10, resolve@npm:^1.22.4, resolve@npm:^1.22.8":
   version: 1.22.10
   resolution: "resolve@npm:1.22.10"
   dependencies:
@@ -14648,7 +14718,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.10#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.10#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
   version: 1.22.10
   resolution: "resolve@patch:resolve@npm%3A1.22.10#optional!builtin<compat/resolve>::version=1.22.10&hash=c3c19d"
   dependencies:
@@ -14863,6 +14933,16 @@ __metadata:
     seek-bunzip: bin/seek-bunzip
     seek-table: bin/seek-bzip-table
   checksum: 10/e47967b694ba51b87a4e7b388772f9c9f6826547972c4c0d2f72b6dd9a41825fe63e810ad56be0f1bcba71c90550b7cb3aee53c261b9aebc15af1cd04fae008f
+  languageName: node
+  linkType: hard
+
+"selfsigned@npm:^2.0.1":
+  version: 2.4.1
+  resolution: "selfsigned@npm:2.4.1"
+  dependencies:
+    "@types/node-forge": "npm:^1.3.0"
+    node-forge: "npm:^1"
+  checksum: 10/52536623f1cfdeb2f8b9198377f2ce7931c677ea69421238d1dc1ea2983bbe258e56c19e7d1af87035cad7270f19b7e996eaab1212e724d887722502f68e17f2
   languageName: node
   linkType: hard
 
@@ -16377,16 +16457,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unenv@npm:unenv-nightly@2.0.0-20250109-100802-88ad671":
-  version: 2.0.0-20250109-100802-88ad671
-  resolution: "unenv-nightly@npm:2.0.0-20250109-100802-88ad671"
+"unenv@npm:unenv-nightly@2.0.0-20240919-125358-9a64854":
+  version: 2.0.0-20240919-125358-9a64854
+  resolution: "unenv-nightly@npm:2.0.0-20240919-125358-9a64854"
   dependencies:
     defu: "npm:^6.1.4"
-    mlly: "npm:^1.7.3"
     ohash: "npm:^1.1.4"
     pathe: "npm:^1.1.2"
     ufo: "npm:^1.5.4"
-  checksum: 10/99f45f1f095704a97db7094931aa88e924cbcd019cf118a3223497b14e645c245dc2bc03833d5c6ed4864b12ec0c36b0b2d3a93392a4d5a2213c28f028f3c8ed
+  checksum: 10/af260151b3c2b4bb6e1d9a2d419f757b4a7d34ab643d953fd61842291d5f847fba3eb50f0f1344055df568bfd271d3c4cc50392cc326629fc895ac6f05362796
   languageName: node
   linkType: hard
 
@@ -17004,15 +17083,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workerd@npm:1.20241230.0":
-  version: 1.20241230.0
-  resolution: "workerd@npm:1.20241230.0"
+"workerd@npm:1.20240925.0":
+  version: 1.20240925.0
+  resolution: "workerd@npm:1.20240925.0"
   dependencies:
-    "@cloudflare/workerd-darwin-64": "npm:1.20241230.0"
-    "@cloudflare/workerd-darwin-arm64": "npm:1.20241230.0"
-    "@cloudflare/workerd-linux-64": "npm:1.20241230.0"
-    "@cloudflare/workerd-linux-arm64": "npm:1.20241230.0"
-    "@cloudflare/workerd-windows-64": "npm:1.20241230.0"
+    "@cloudflare/workerd-darwin-64": "npm:1.20240925.0"
+    "@cloudflare/workerd-darwin-arm64": "npm:1.20240925.0"
+    "@cloudflare/workerd-linux-64": "npm:1.20240925.0"
+    "@cloudflare/workerd-linux-arm64": "npm:1.20240925.0"
+    "@cloudflare/workerd-windows-64": "npm:1.20240925.0"
   dependenciesMeta:
     "@cloudflare/workerd-darwin-64":
       optional: true
@@ -17026,7 +17105,7 @@ __metadata:
       optional: true
   bin:
     workerd: bin/workerd
-  checksum: 10/4d13110a38ed75f53740e5a521b492ef617cf5d82c1715efbc2747255bcac0caf78a57456d42a820b8b8e8f74b10c801c63c73fe5b3eab4f1ff4a73e8a6852af
+  checksum: 10/5be8ec01093d3a44c7983935c6c44ea6570d3533b8ea3a6191717ff8d0b2c6d7a28d6d3e1e21a2de3913a4903bc1b4efc5947e19f381be1302c1303045001771
   languageName: node
   linkType: hard
 
@@ -17111,7 +17190,7 @@ __metadata:
     typescript: "npm:^5.3.3"
     vitest: "npm:^0.33.0"
     vitest-environment-miniflare: "npm:^2.14.2"
-    wrangler: "npm:3.103.2"
+    wrangler: "npm:3.80.0"
   languageName: unknown
   linkType: soft
 
@@ -17124,22 +17203,30 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"wrangler@npm:3.103.2":
-  version: 3.103.2
-  resolution: "wrangler@npm:3.103.2"
+"wrangler@npm:3.80.0":
+  version: 3.80.0
+  resolution: "wrangler@npm:3.80.0"
   dependencies:
     "@cloudflare/kv-asset-handler": "npm:0.3.4"
-    "@esbuild-plugins/node-globals-polyfill": "npm:0.2.3"
-    "@esbuild-plugins/node-modules-polyfill": "npm:0.2.2"
-    blake3-wasm: "npm:2.1.5"
+    "@cloudflare/workers-shared": "npm:0.5.4"
+    "@esbuild-plugins/node-globals-polyfill": "npm:^0.2.3"
+    "@esbuild-plugins/node-modules-polyfill": "npm:^0.2.2"
+    blake3-wasm: "npm:^2.1.5"
+    chokidar: "npm:^3.5.3"
     esbuild: "npm:0.17.19"
     fsevents: "npm:~2.3.2"
-    miniflare: "npm:3.20241230.2"
-    path-to-regexp: "npm:6.3.0"
-    unenv: "npm:unenv-nightly@2.0.0-20250109-100802-88ad671"
-    workerd: "npm:1.20241230.0"
+    miniflare: "npm:3.20240925.0"
+    nanoid: "npm:^3.3.3"
+    path-to-regexp: "npm:^6.3.0"
+    resolve: "npm:^1.22.8"
+    resolve.exports: "npm:^2.0.2"
+    selfsigned: "npm:^2.0.1"
+    source-map: "npm:^0.6.1"
+    unenv: "npm:unenv-nightly@2.0.0-20240919-125358-9a64854"
+    workerd: "npm:1.20240925.0"
+    xxhash-wasm: "npm:^1.0.1"
   peerDependencies:
-    "@cloudflare/workers-types": ^4.20241230.0
+    "@cloudflare/workers-types": ^4.20240925.0
   dependenciesMeta:
     fsevents:
       optional: true
@@ -17149,7 +17236,7 @@ __metadata:
   bin:
     wrangler: bin/wrangler.js
     wrangler2: bin/wrangler.js
-  checksum: 10/6e364dd9e02555ab57ff95f2dffea590933c76d76389f10c80a3c739daff4394b24bda3dd8ac0a1e07436a8e61a34b7c8db87c44000db086d023889d0f231ecb
+  checksum: 10/026eed9e10f24f8ecbecf0ad8ec03d5935553a097595e4a6f154e755ba6df4bce0c5cc9159b14a4e0e174fbb0bec471ecf0d884be747be080eeccf801d8954cc
   languageName: node
   linkType: hard
 
@@ -17283,7 +17370,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.11.0, ws@npm:^8.18.0, ws@npm:^8.2.2":
+"ws@npm:^8.11.0, ws@npm:^8.17.1, ws@npm:^8.2.2":
   version: 8.18.3
   resolution: "ws@npm:8.18.3"
   peerDependencies:
@@ -17334,6 +17421,13 @@ __metadata:
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: 10/ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a
+  languageName: node
+  linkType: hard
+
+"xxhash-wasm@npm:^1.0.1":
+  version: 1.1.0
+  resolution: "xxhash-wasm@npm:1.1.0"
+  checksum: 10/cad149dabda4ec4ce7c2edd98815c4cc21eadab72f631c832af110066867850fb86b9430499707358d3e23cafe6d71d0a5c16be8f1864f213e4cd1aa74bd9556
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1996,6 +1996,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cloudflare/unenv-preset@npm:2.3.2":
+  version: 2.3.2
+  resolution: "@cloudflare/unenv-preset@npm:2.3.2"
+  peerDependencies:
+    unenv: 2.0.0-rc.17
+    workerd: ^1.20250508.0
+  peerDependenciesMeta:
+    workerd:
+      optional: true
+  checksum: 10/1b57947de56cd8206e638cebdc9da7ff9f7d8f272c6a8be74aa0ee0a19ddf750c4bbce98b5cd3ea805851b5053e5ea313b188208a472c3c604fd089ff2869c92
+  languageName: node
+  linkType: hard
+
 "@cloudflare/unenv-preset@npm:2.6.2":
   version: 2.6.2
   resolution: "@cloudflare/unenv-preset@npm:2.6.2"
@@ -2009,9 +2022,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-darwin-64@npm:1.20240925.0":
-  version: 1.20240925.0
-  resolution: "@cloudflare/workerd-darwin-64@npm:1.20240925.0"
+"@cloudflare/workerd-darwin-64@npm:1.20250604.0":
+  version: 1.20250604.0
+  resolution: "@cloudflare/workerd-darwin-64@npm:1.20250604.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -2030,9 +2043,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-darwin-arm64@npm:1.20240925.0":
-  version: 1.20240925.0
-  resolution: "@cloudflare/workerd-darwin-arm64@npm:1.20240925.0"
+"@cloudflare/workerd-darwin-arm64@npm:1.20250604.0":
+  version: 1.20250604.0
+  resolution: "@cloudflare/workerd-darwin-arm64@npm:1.20250604.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -2051,9 +2064,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-linux-64@npm:1.20240925.0":
-  version: 1.20240925.0
-  resolution: "@cloudflare/workerd-linux-64@npm:1.20240925.0"
+"@cloudflare/workerd-linux-64@npm:1.20250604.0":
+  version: 1.20250604.0
+  resolution: "@cloudflare/workerd-linux-64@npm:1.20250604.0"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
@@ -2072,9 +2085,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-linux-arm64@npm:1.20240925.0":
-  version: 1.20240925.0
-  resolution: "@cloudflare/workerd-linux-arm64@npm:1.20240925.0"
+"@cloudflare/workerd-linux-arm64@npm:1.20250604.0":
+  version: 1.20250604.0
+  resolution: "@cloudflare/workerd-linux-arm64@npm:1.20250604.0"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
@@ -2093,9 +2106,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-windows-64@npm:1.20240925.0":
-  version: 1.20240925.0
-  resolution: "@cloudflare/workerd-windows-64@npm:1.20240925.0"
+"@cloudflare/workerd-windows-64@npm:1.20250604.0":
+  version: 1.20250604.0
+  resolution: "@cloudflare/workerd-windows-64@npm:1.20250604.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2111,16 +2124,6 @@ __metadata:
   version: 1.20250816.0
   resolution: "@cloudflare/workerd-windows-64@npm:1.20250816.0"
   conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@cloudflare/workers-shared@npm:0.5.4":
-  version: 0.5.4
-  resolution: "@cloudflare/workers-shared@npm:0.5.4"
-  dependencies:
-    mime: "npm:^3.0.0"
-    zod: "npm:^3.22.3"
-  checksum: 10/161600b627169048ae7fe7108363d8ef83e273db4f3fd0677ab296d444529e73662d192d3d841c09722f557a57295b738bddb2fc644a267968f7b57acef9e68b
   languageName: node
   linkType: hard
 
@@ -2374,7 +2377,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild-plugins/node-globals-polyfill@npm:0.2.3, @esbuild-plugins/node-globals-polyfill@npm:^0.2.3":
+"@esbuild-plugins/node-globals-polyfill@npm:0.2.3":
   version: 0.2.3
   resolution: "@esbuild-plugins/node-globals-polyfill@npm:0.2.3"
   peerDependencies:
@@ -2383,7 +2386,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild-plugins/node-modules-polyfill@npm:0.2.2, @esbuild-plugins/node-modules-polyfill@npm:^0.2.2":
+"@esbuild-plugins/node-modules-polyfill@npm:0.2.2":
   version: 0.2.2
   resolution: "@esbuild-plugins/node-modules-polyfill@npm:0.2.2"
   dependencies:
@@ -5526,15 +5529,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node-forge@npm:^1.3.0":
-  version: 1.3.14
-  resolution: "@types/node-forge@npm:1.3.14"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10/500ce72435285fca145837da079b49a09a5bdf8391b0effc3eb2455783dd81ab129e574a36e1a0374a4823d889d5328177ebfd6fe45b432c0c43d48d790fe39c
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:*":
   version: 24.3.0
   resolution: "@types/node@npm:24.3.0"
@@ -6330,7 +6324,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.1.0, acorn@npm:^8.10.0, acorn@npm:^8.11.0, acorn@npm:^8.14.0, acorn@npm:^8.4.1, acorn@npm:^8.6.0, acorn@npm:^8.8.0, acorn@npm:^8.8.1, acorn@npm:^8.9.0":
+"acorn@npm:^8.1.0, acorn@npm:^8.10.0, acorn@npm:^8.11.0, acorn@npm:^8.14.0, acorn@npm:^8.4.1, acorn@npm:^8.6.0, acorn@npm:^8.8.1, acorn@npm:^8.9.0":
   version: 8.15.0
   resolution: "acorn@npm:8.15.0"
   bin:
@@ -6432,7 +6426,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"anymatch@npm:^3.0.3, anymatch@npm:~3.1.2":
+"anymatch@npm:^3.0.3":
   version: 3.1.3
   resolution: "anymatch@npm:3.1.3"
   dependencies:
@@ -6910,13 +6904,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"binary-extensions@npm:^2.0.0":
-  version: 2.3.0
-  resolution: "binary-extensions@npm:2.3.0"
-  checksum: 10/bcad01494e8a9283abf18c1b967af65ee79b0c6a9e6fcfafebfe91dbe6e0fc7272bafb73389e198b310516ae04f7ad17d79aacf6cb4c0d5d5202a7e2e52c7d98
-  languageName: node
-  linkType: hard
-
 "bindings@npm:^1.4.0, bindings@npm:^1.5.0":
   version: 1.5.0
   resolution: "bindings@npm:1.5.0"
@@ -6947,7 +6934,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"blake3-wasm@npm:2.1.5, blake3-wasm@npm:^2.1.5":
+"blake3-wasm@npm:2.1.5":
   version: 2.1.5
   resolution: "blake3-wasm@npm:2.1.5"
   checksum: 10/7138aa209ac8411755ba07df7d035974886aac1fb4bb8cf710d354732037069bacc9984c19b3bc68bf5e17cc203f454cc9cfcb7115393aaf21ce865630dbf920
@@ -6980,7 +6967,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"braces@npm:^3.0.3, braces@npm:~3.0.2":
+"braces@npm:^3.0.3":
   version: 3.0.3
   resolution: "braces@npm:3.0.3"
   dependencies:
@@ -7172,16 +7159,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"capnp-ts@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "capnp-ts@npm:0.7.0"
-  dependencies:
-    debug: "npm:^4.3.1"
-    tslib: "npm:^2.2.0"
-  checksum: 10/186a76662e31ab16fe46fe0785ed2a511969d0c5198e2d7baec6b44f71c9b3bf8c05e7627036dc86c2d3ddc229c846559350c13f904fdd8da3590d7054715ba8
-  languageName: node
-  linkType: hard
-
 "chai@npm:^4.3.7":
   version: 4.5.0
   resolution: "chai@npm:4.5.0"
@@ -7253,25 +7230,6 @@ __metadata:
   dependencies:
     readdirp: "npm:^4.0.1"
   checksum: 10/e9a65db724a9ba2a40ad10f1d55caa5ccb5ba17533414271ec315004664860439348e51fa4faaa640fcc5f6427a410919fa1608892fbad41ed86fce682633cfa
-  languageName: node
-  linkType: hard
-
-"chokidar@npm:^3.5.3":
-  version: 3.6.0
-  resolution: "chokidar@npm:3.6.0"
-  dependencies:
-    anymatch: "npm:~3.1.2"
-    braces: "npm:~3.0.2"
-    fsevents: "npm:~2.3.2"
-    glob-parent: "npm:~5.1.2"
-    is-binary-path: "npm:~2.1.0"
-    is-glob: "npm:~4.0.1"
-    normalize-path: "npm:~3.0.0"
-    readdirp: "npm:~3.6.0"
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  checksum: 10/c327fb07704443f8d15f7b4a7ce93b2f0bc0e6cea07ec28a7570aa22cd51fcf0379df589403976ea956c369f25aa82d84561947e227cd925902e1751371658df
   languageName: node
   linkType: hard
 
@@ -10015,7 +9973,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"exit-hook@npm:2.2.1, exit-hook@npm:^2.2.1":
+"exit-hook@npm:2.2.1":
   version: 2.2.1
   resolution: "exit-hook@npm:2.2.1"
   checksum: 10/75835919e0aca624daa8d114c0014ae84506c4b79ac5806748cc7a86d1610a864ee974be58eec823c7757e5e6b07a5e332647e20ef84f6cc3dc3385c953c78c9
@@ -10083,7 +10041,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"exsolve@npm:^1.0.1, exsolve@npm:^1.0.7":
+"exsolve@npm:^1.0.1, exsolve@npm:^1.0.4, exsolve@npm:^1.0.7":
   version: 1.0.7
   resolution: "exsolve@npm:1.0.7"
   checksum: 10/0c9fc0964da0154f38b55e612ed29bf5040f753d5d2db3a63559762237d0a86290e2f18997973343bb9900c07ab1e48596321de9d9d338e373b1f3f1a015e4c9
@@ -10632,7 +10590,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
+"glob-parent@npm:^5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
@@ -10650,7 +10608,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-to-regexp@npm:0.4.1, glob-to-regexp@npm:^0.4.1":
+"glob-to-regexp@npm:0.4.1":
   version: 0.4.1
   resolution: "glob-to-regexp@npm:0.4.1"
   checksum: 10/9009529195a955c40d7b9690794aeff5ba665cc38f1519e111c58bb54366fd0c106bde80acf97ba4e533208eb53422c83b136611a54c5fefb1edd8dc267cb62e
@@ -11127,15 +11085,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-binary-path@npm:~2.1.0":
-  version: 2.1.0
-  resolution: "is-binary-path@npm:2.1.0"
-  dependencies:
-    binary-extensions: "npm:^2.0.0"
-  checksum: 10/078e51b4f956c2c5fd2b26bb2672c3ccf7e1faff38e0ebdba45612265f4e3d9fc3127a1fa8370bbf09eab61339203c3d3b7af5662cbf8be4030f8fac37745b0e
-  languageName: node
-  linkType: hard
-
 "is-boolean-object@npm:^1.2.1":
   version: 1.2.2
   resolution: "is-boolean-object@npm:1.2.2"
@@ -11241,7 +11190,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3, is-glob@npm:~4.0.1":
+"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3":
   version: 4.0.3
   resolution: "is-glob@npm:4.0.3"
   dependencies:
@@ -12797,28 +12746,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"miniflare@npm:3.20240925.0":
-  version: 3.20240925.0
-  resolution: "miniflare@npm:3.20240925.0"
-  dependencies:
-    "@cspotcode/source-map-support": "npm:0.8.1"
-    acorn: "npm:^8.8.0"
-    acorn-walk: "npm:^8.2.0"
-    capnp-ts: "npm:^0.7.0"
-    exit-hook: "npm:^2.2.1"
-    glob-to-regexp: "npm:^0.4.1"
-    stoppable: "npm:^1.1.0"
-    undici: "npm:^5.28.4"
-    workerd: "npm:1.20240925.0"
-    ws: "npm:^8.17.1"
-    youch: "npm:^3.2.2"
-    zod: "npm:^3.22.3"
-  bin:
-    miniflare: bootstrap.js
-  checksum: 10/d5003262fc82b794b00893367eb4a337f4e04c6918c518569913c47b5ffbc21a18018db2450a319b359d6416b2ad08ce920cbb1243a49977538a304877fa3269
-  languageName: node
-  linkType: hard
-
 "miniflare@npm:3.20250718.1":
   version: 3.20250718.1
   resolution: "miniflare@npm:3.20250718.1"
@@ -12837,6 +12764,28 @@ __metadata:
   bin:
     miniflare: bootstrap.js
   checksum: 10/5802e52d19b0dc16c20fe89eccf3ef498c3a00ab7f807a1519518f954cfbd708f8ad2969e86d74a28f7277bec0e92b3cddda66dd5a6b358772a5d68dd3b2b76e
+  languageName: node
+  linkType: hard
+
+"miniflare@npm:4.20250604.1":
+  version: 4.20250604.1
+  resolution: "miniflare@npm:4.20250604.1"
+  dependencies:
+    "@cspotcode/source-map-support": "npm:0.8.1"
+    acorn: "npm:8.14.0"
+    acorn-walk: "npm:8.3.2"
+    exit-hook: "npm:2.2.1"
+    glob-to-regexp: "npm:0.4.1"
+    sharp: "npm:^0.33.5"
+    stoppable: "npm:1.1.0"
+    undici: "npm:^5.28.5"
+    workerd: "npm:1.20250604.0"
+    ws: "npm:8.18.0"
+    youch: "npm:3.3.4"
+    zod: "npm:3.22.3"
+  bin:
+    miniflare: bootstrap.js
+  checksum: 10/a89e838e07dec6f552c062779fa6174ffb17340620cd636d344d4d8a25229356815ec772e11e1b9bfa0fa2bafc8ab7b4e73c5ffdb9af2f92d81efdd87d076470
   languageName: node
   linkType: hard
 
@@ -13061,7 +13010,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11, nanoid@npm:^3.3.3, nanoid@npm:^3.3.6, nanoid@npm:^3.3.7":
+"nanoid@npm:^3.3.11, nanoid@npm:^3.3.6, nanoid@npm:^3.3.7":
   version: 3.3.11
   resolution: "nanoid@npm:3.3.11"
   bin:
@@ -13230,13 +13179,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-forge@npm:^1":
-  version: 1.3.1
-  resolution: "node-forge@npm:1.3.1"
-  checksum: 10/05bab6868633bf9ad4c3b1dd50ec501c22ffd69f556cdf169a00998ca1d03e8107a6032ba013852f202035372021b845603aeccd7dfcb58cdb7430013b3daa8d
-  languageName: node
-  linkType: hard
-
 "node-gyp-build@npm:^4.2.2":
   version: 4.8.4
   resolution: "node-gyp-build@npm:4.8.4"
@@ -13316,7 +13258,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-path@npm:^3.0.0, normalize-path@npm:~3.0.0":
+"normalize-path@npm:^3.0.0":
   version: 3.0.0
   resolution: "normalize-path@npm:3.0.0"
   checksum: 10/88eeb4da891e10b1318c4b2476b6e2ecbeb5ff97d946815ffea7794c31a89017c70d7f34b3c2ebf23ef4e9fc9fb99f7dffe36da22011b5b5c6ffa34f4873ec20
@@ -13465,13 +13407,6 @@ __metadata:
     define-properties: "npm:^1.2.1"
     es-object-atoms: "npm:^1.0.0"
   checksum: 10/f5ec9eccdefeaaa834b089c525663436812a65ff13de7964a1c3a9110f32054f2d58aa476a645bb14f75a79f3fe1154fb3e7bfdae7ac1e80affe171b2ef74bce
-  languageName: node
-  linkType: hard
-
-"ohash@npm:^1.1.4":
-  version: 1.1.6
-  resolution: "ohash@npm:1.1.6"
-  checksum: 10/068a7087f99cb43a60d5b1933bade732fecd5446337447735edfe1e6e5de78c91949eb1d79a0372a2b48b608f2b50ea7b56347b3fcd45526bffd5c4a9d5e2221
   languageName: node
   linkType: hard
 
@@ -13755,7 +13690,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp-updated@npm:path-to-regexp@6.3.0, path-to-regexp@npm:6.3.0, path-to-regexp@npm:^6.3.0":
+"path-to-regexp-updated@npm:path-to-regexp@6.3.0, path-to-regexp@npm:6.3.0":
   version: 6.3.0
   resolution: "path-to-regexp@npm:6.3.0"
   checksum: 10/6822f686f01556d99538b350722ef761541ec0ce95ca40ce4c29e20a5b492fe8361961f57993c71b2418de12e604478dcf7c430de34b2c31a688363a7a944d9c
@@ -13785,7 +13720,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pathe@npm:^1.1.1, pathe@npm:^1.1.2":
+"pathe@npm:^1.1.1":
   version: 1.1.2
   resolution: "pathe@npm:1.1.2"
   checksum: 10/f201d796351bf7433d147b92c20eb154a4e0ea83512017bf4ec4e492a5d6e738fb45798be4259a61aa81270179fce11026f6ff0d3fa04173041de044defe9d80
@@ -13827,7 +13762,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10/60c2595003b05e4535394d1da94850f5372c9427ca4413b71210f437f7b2ca091dbd611c45e8b37d10036fa8eade25c1b8951654f9d3973bfa66a2ff4d3b08bc
@@ -14537,15 +14472,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readdirp@npm:~3.6.0":
-  version: 3.6.0
-  resolution: "readdirp@npm:3.6.0"
-  dependencies:
-    picomatch: "npm:^2.2.1"
-  checksum: 10/196b30ef6ccf9b6e18c4e1724b7334f72a093d011a99f3b5920470f0b3406a51770867b3e1ae9711f227ef7a7065982f6ee2ce316746b2cb42c88efe44297fe7
-  languageName: node
-  linkType: hard
-
 "redent@npm:^3.0.0":
   version: 3.0.0
   resolution: "redent@npm:3.0.0"
@@ -14685,14 +14611,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve.exports@npm:^2.0.0, resolve.exports@npm:^2.0.2":
+"resolve.exports@npm:^2.0.0":
   version: 2.0.3
   resolution: "resolve.exports@npm:2.0.3"
   checksum: 10/536efee0f30a10fac8604e6cdc7844dbc3f4313568d09f06db4f7ed8a5b8aeb8585966fe975083d1f2dfbc87cf5f8bc7ab65a5c23385c14acbb535ca79f8398a
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.10, resolve@npm:^1.22.4, resolve@npm:^1.22.8":
+"resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.10, resolve@npm:^1.22.4":
   version: 1.22.10
   resolution: "resolve@npm:1.22.10"
   dependencies:
@@ -14718,7 +14644,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.10#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.10#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
   version: 1.22.10
   resolution: "resolve@patch:resolve@npm%3A1.22.10#optional!builtin<compat/resolve>::version=1.22.10&hash=c3c19d"
   dependencies:
@@ -14933,16 +14859,6 @@ __metadata:
     seek-bunzip: bin/seek-bunzip
     seek-table: bin/seek-bzip-table
   checksum: 10/e47967b694ba51b87a4e7b388772f9c9f6826547972c4c0d2f72b6dd9a41825fe63e810ad56be0f1bcba71c90550b7cb3aee53c261b9aebc15af1cd04fae008f
-  languageName: node
-  linkType: hard
-
-"selfsigned@npm:^2.0.1":
-  version: 2.4.1
-  resolution: "selfsigned@npm:2.4.1"
-  dependencies:
-    "@types/node-forge": "npm:^1.3.0"
-    node-forge: "npm:^1"
-  checksum: 10/52536623f1cfdeb2f8b9198377f2ce7931c677ea69421238d1dc1ea2983bbe258e56c19e7d1af87035cad7270f19b7e996eaab1212e724d887722502f68e17f2
   languageName: node
   linkType: hard
 
@@ -15483,7 +15399,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stoppable@npm:1.1.0, stoppable@npm:^1.1.0":
+"stoppable@npm:1.1.0":
   version: 1.1.0
   resolution: "stoppable@npm:1.1.0"
   checksum: 10/63104fcbdece130bc4906fd982061e763d2ef48065ed1ab29895e5ad00552c625f8a4c50c9cd2e3bfa805c8a2c3bfdda0f07c5ae39694bd2d5cb0bee1618d1e9
@@ -16201,7 +16117,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.4.0":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
@@ -16444,6 +16360,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unenv@npm:2.0.0-rc.17":
+  version: 2.0.0-rc.17
+  resolution: "unenv@npm:2.0.0-rc.17"
+  dependencies:
+    defu: "npm:^6.1.4"
+    exsolve: "npm:^1.0.4"
+    ohash: "npm:^2.0.11"
+    pathe: "npm:^2.0.3"
+    ufo: "npm:^1.6.1"
+  checksum: 10/e723308064cf1e111be9899259ecee54cac214be9446f165d217269d666cda3166209fe75ae1da0560e6a4ecb1bdecf7197628c2accc279616b54c3c90db4b20
+  languageName: node
+  linkType: hard
+
 "unenv@npm:2.0.0-rc.19":
   version: 2.0.0-rc.19
   resolution: "unenv@npm:2.0.0-rc.19"
@@ -16454,18 +16383,6 @@ __metadata:
     pathe: "npm:^2.0.3"
     ufo: "npm:^1.6.1"
   checksum: 10/37c0a8cd30decd396785ca8b632131758a10a8fd75e5e5560f0fb0857e6e98b48cc55739f40e84b92c304cb6c866e768c4fb683afe48e76468813e98a41dc2f4
-  languageName: node
-  linkType: hard
-
-"unenv@npm:unenv-nightly@2.0.0-20240919-125358-9a64854":
-  version: 2.0.0-20240919-125358-9a64854
-  resolution: "unenv-nightly@npm:2.0.0-20240919-125358-9a64854"
-  dependencies:
-    defu: "npm:^6.1.4"
-    ohash: "npm:^1.1.4"
-    pathe: "npm:^1.1.2"
-    ufo: "npm:^1.5.4"
-  checksum: 10/af260151b3c2b4bb6e1d9a2d419f757b4a7d34ab643d953fd61842291d5f847fba3eb50f0f1344055df568bfd271d3c4cc50392cc326629fc895ac6f05362796
   languageName: node
   linkType: hard
 
@@ -17083,15 +17000,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workerd@npm:1.20240925.0":
-  version: 1.20240925.0
-  resolution: "workerd@npm:1.20240925.0"
+"workerd@npm:1.20250604.0":
+  version: 1.20250604.0
+  resolution: "workerd@npm:1.20250604.0"
   dependencies:
-    "@cloudflare/workerd-darwin-64": "npm:1.20240925.0"
-    "@cloudflare/workerd-darwin-arm64": "npm:1.20240925.0"
-    "@cloudflare/workerd-linux-64": "npm:1.20240925.0"
-    "@cloudflare/workerd-linux-arm64": "npm:1.20240925.0"
-    "@cloudflare/workerd-windows-64": "npm:1.20240925.0"
+    "@cloudflare/workerd-darwin-64": "npm:1.20250604.0"
+    "@cloudflare/workerd-darwin-arm64": "npm:1.20250604.0"
+    "@cloudflare/workerd-linux-64": "npm:1.20250604.0"
+    "@cloudflare/workerd-linux-arm64": "npm:1.20250604.0"
+    "@cloudflare/workerd-windows-64": "npm:1.20250604.0"
   dependenciesMeta:
     "@cloudflare/workerd-darwin-64":
       optional: true
@@ -17105,7 +17022,7 @@ __metadata:
       optional: true
   bin:
     workerd: bin/workerd
-  checksum: 10/5be8ec01093d3a44c7983935c6c44ea6570d3533b8ea3a6191717ff8d0b2c6d7a28d6d3e1e21a2de3913a4903bc1b4efc5947e19f381be1302c1303045001771
+  checksum: 10/22a1002e364292b0be89ec645d0eff2b35feee9216b237b53169f2b1f2437bb2a8de7acde27a70aa9923981412e19a561ca20678ab66b48f3dce68e81d0b665a
   languageName: node
   linkType: hard
 
@@ -17190,7 +17107,7 @@ __metadata:
     typescript: "npm:^5.3.3"
     vitest: "npm:^0.33.0"
     vitest-environment-miniflare: "npm:^2.14.2"
-    wrangler: "npm:3.80.0"
+    wrangler: "npm:4.20.0"
   languageName: unknown
   linkType: soft
 
@@ -17203,30 +17120,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"wrangler@npm:3.80.0":
-  version: 3.80.0
-  resolution: "wrangler@npm:3.80.0"
+"wrangler@npm:4.20.0":
+  version: 4.20.0
+  resolution: "wrangler@npm:4.20.0"
   dependencies:
-    "@cloudflare/kv-asset-handler": "npm:0.3.4"
-    "@cloudflare/workers-shared": "npm:0.5.4"
-    "@esbuild-plugins/node-globals-polyfill": "npm:^0.2.3"
-    "@esbuild-plugins/node-modules-polyfill": "npm:^0.2.2"
-    blake3-wasm: "npm:^2.1.5"
-    chokidar: "npm:^3.5.3"
-    esbuild: "npm:0.17.19"
+    "@cloudflare/kv-asset-handler": "npm:0.4.0"
+    "@cloudflare/unenv-preset": "npm:2.3.2"
+    blake3-wasm: "npm:2.1.5"
+    esbuild: "npm:0.25.4"
     fsevents: "npm:~2.3.2"
-    miniflare: "npm:3.20240925.0"
-    nanoid: "npm:^3.3.3"
-    path-to-regexp: "npm:^6.3.0"
-    resolve: "npm:^1.22.8"
-    resolve.exports: "npm:^2.0.2"
-    selfsigned: "npm:^2.0.1"
-    source-map: "npm:^0.6.1"
-    unenv: "npm:unenv-nightly@2.0.0-20240919-125358-9a64854"
-    workerd: "npm:1.20240925.0"
-    xxhash-wasm: "npm:^1.0.1"
+    miniflare: "npm:4.20250604.1"
+    path-to-regexp: "npm:6.3.0"
+    unenv: "npm:2.0.0-rc.17"
+    workerd: "npm:1.20250604.0"
   peerDependencies:
-    "@cloudflare/workers-types": ^4.20240925.0
+    "@cloudflare/workers-types": ^4.20250604.0
   dependenciesMeta:
     fsevents:
       optional: true
@@ -17236,7 +17144,7 @@ __metadata:
   bin:
     wrangler: bin/wrangler.js
     wrangler2: bin/wrangler.js
-  checksum: 10/026eed9e10f24f8ecbecf0ad8ec03d5935553a097595e4a6f154e755ba6df4bce0c5cc9159b14a4e0e174fbb0bec471ecf0d884be747be080eeccf801d8954cc
+  checksum: 10/ad8b35a775631d37f1e9543c1f62491a9ff8c61b5b45b67dd974476944bcba18f5f49935af3e5d5564fcad4bcdde79f19c57c553eaafac5e9194da6bb78762b1
   languageName: node
   linkType: hard
 
@@ -17370,7 +17278,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.11.0, ws@npm:^8.17.1, ws@npm:^8.2.2":
+"ws@npm:^8.11.0, ws@npm:^8.2.2":
   version: 8.18.3
   resolution: "ws@npm:8.18.3"
   peerDependencies:
@@ -17421,13 +17329,6 @@ __metadata:
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: 10/ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a
-  languageName: node
-  linkType: hard
-
-"xxhash-wasm@npm:^1.0.1":
-  version: 1.1.0
-  resolution: "xxhash-wasm@npm:1.1.0"
-  checksum: 10/cad149dabda4ec4ce7c2edd98815c4cc21eadab72f631c832af110066867850fb86b9430499707358d3e23cafe6d71d0a5c16be8f1864f213e4cd1aa74bd9556
   languageName: node
   linkType: hard
 
@@ -17558,7 +17459,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"youch@npm:3.3.4, youch@npm:^3.2.2":
+"youch@npm:3.3.4":
   version: 3.3.4
   resolution: "youch@npm:3.3.4"
   dependencies:
@@ -17586,12 +17487,5 @@ __metadata:
   version: 3.22.3
   resolution: "zod@npm:3.22.3"
   checksum: 10/3aad6e6b61ddceaeb887dccc5f747903e619b09dfd208f6dc30eef15edf3942b8e6cd97a08e080c9c8723575446941edb823a8881c512e00e8dd3085f20659cc
-  languageName: node
-  linkType: hard
-
-"zod@npm:^3.22.3":
-  version: 3.25.76
-  resolution: "zod@npm:3.25.76"
-  checksum: 10/f0c963ec40cd96858451d1690404d603d36507c1fc9682f2dae59ab38b578687d542708a7fdbf645f77926f78c9ed558f57c3d3aa226c285f798df0c4da16995
   languageName: node
   linkType: hard


### PR DESCRIPTION
Changes to how insitution logos are retrieved.

Made a new function in api.ts `entityImageLoader()`. Which takes an entity and a size. When supplied a country entity, it returns the appropriate logo via the `cokiImageLoader()` function. When supplied with an insitution entity, returns a new route to our backend api host.

Added a new route and handler in our backend API:
- Route: `/logos/:entityId`
- Hander: `fetchLogoHandler()` takes an entityId and a size parameter. Queries the backend KV store to retrieve the domain of the entity if it exists. Then fetches the logo (using the size param) from logo.dev and returns the jpeg image asynchronously.

Updates all `cokiImageLoader()` calls to instead use the new `entityImageLoader()` function.

Also updates the D1 database loading. Wrangler does not like how we're loading the data, so I made a script to load it in batches. This seems to be a wrangler bug, If it ever gets fixed, we should revert it to the simpler way.


